### PR TITLE
feat+fix+docs: sidebar update banner, auth on /review/apply, README, provider docs, launch post

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,75 +1,104 @@
 # Archivista AI
 
-AI autopilot for [Paperless-ngx](https://docs.paperless-ngx.com/).
+AI autopilot for [Paperless-ngx](https://docs.paperless-ngx.com/) — self-hosted document classification, tagging, and owner assignment.
 
-Archivista AI is a ground-up document filing extension that connects to your
-Paperless-ngx instance, analyzes OCR content and metadata, then writes useful
-filing information back into Paperless:
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![Latest release](https://img.shields.io/github/v/release/arturict/archivista-ai)](https://github.com/arturict/archivista-ai/releases)
+[![CI](https://img.shields.io/github/actions/workflow/status/arturict/archivista-ai/ci.yml?branch=main&label=CI)](https://github.com/arturict/archivista-ai/actions/workflows/ci.yml)
 
-- titles
-- tags
-- correspondent
-- document type
-- document date/language
-- custom fields
-- Paperless owner/person assignment
+## What it does
 
-It is built for fast setup: scan for Paperless, paste one API token, choose a
-model provider, and let it process new documents.
+Archivista AI connects to your Paperless-ngx instance, reads OCR content and existing metadata for incoming documents, and writes back useful filing information: a generated title, tags, correspondent, document type, document date and language, custom fields, and an optional Paperless user/owner assignment. The service polls Paperless for new documents, processes them through a configurable model provider, and updates the original record. The web UI exposes setup, history, manual re-runs, and a per-provider settings panel.
 
-## Model Providers
+![Archivista AI dashboard](dashboard.png)
 
-- OpenAI Direct: `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.3`
-- OpenRouter with `company/model` slugs
-- Ollama
-- LM Studio / OpenAI-compatible APIs
-- Azure OpenAI
+## Quickstart (Docker Compose)
 
-## Run With Docker
+Save the following as `docker-compose.yml` and run `docker compose up -d`:
 
 ```yaml
 services:
   archivista-ai:
     image: ghcr.io/arturict/archivista-ai:latest
+    container_name: archivista-ai
+    restart: unless-stopped
     ports:
       - "8080:3000"
     environment:
       PAPERLESS_API_URL: http://paperless-ngx:8000
       PAPERLESS_AI_PORT: "3000"
+      AI_PROVIDER: openai
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      OPENAI_MODEL: gpt-5.4-mini
     volumes:
-      - ./data:/app/data
+      - archivista_ai_data:/app/data
+
+volumes:
+  archivista_ai_data:
 ```
 
-Open `/setup`, scan for Paperless-ngx, paste your Paperless API token, and save.
+Then open `http://localhost:8080/setup`, scan for your Paperless-ngx instance, paste a Paperless API token, choose a model provider, and save. The setup wizard stores a non-secret snapshot in `data/.onboarding` and your secrets in `data/.env`.
 
-## Fast Onboarding
+## Model Providers
 
-Archivista writes a non-secret setup snapshot to:
+Archivista AI ships with provider adapters for:
 
-```text
-data/.onboarding
-```
+- **OpenAI Direct** — `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `gpt-5.3`
+- **OpenRouter** — routed access via `company/model` slugs (e.g. `anthropic/claude-sonnet-4.5`)
+- **Ollama** — local models through the Ollama HTTP API
+- **LM Studio / OpenAI-compatible** — any endpoint that speaks the OpenAI Chat Completions API
+- **Azure OpenAI** — Azure-hosted OpenAI deployments
 
-Secrets stay in `data/.env`.
+Per-provider environment variables and troubleshooting are documented in [docs/providers/](docs/providers/README.md).
 
-## Person Assignment
+## How it works
 
-Archivista can assign documents to Paperless users automatically. It matches OCR
-content and AI output against Paperless user profile data (`username`, name,
-email). Optional hints can be added:
+Archivista AI is a Node.js/Express service that talks to Paperless-ngx over its REST API. A polling loop scans for documents added since the last successful run, downloads the OCR text and current metadata, and builds a structured prompt for the configured model provider. The model's JSON response is validated against a schema and written back to Paperless as title, tags, correspondent, type, date, language, custom fields, and an optional owner.
 
-```text
-alex: Alex M., private invoices, health insurance
-finance: accounting team, vendor bills, receipts
-```
+Owners are resolved against Paperless user profiles (`username`, name, email) with optional hints like `alex: Alex M., private invoices, health insurance`. Matching is conservative: a document is only assigned to a user when the model output and the hint context agree, so unrelated files are never silently rerouted.
+
+A small SQLite database tracks processed documents, retries, and error history. Failed runs are retried with exponential backoff, and the web UI shows the full history for inspection and manual reprocessing. The service is designed to be idempotent: re-processing a document overwrites its AI-derived fields without duplicating tags or correspondents.
+
+The whole stack runs as a single container with no external database. The only outbound network calls are to your Paperless instance and to the model provider you configure — see the Security & Privacy section below.
+
+## Roadmap
+
+The full task list lives in [docs/agent-roadmap.json](docs/agent-roadmap.json). The four phases are:
+
+- **Phase 0 — Trust reset.** Remove legacy upstream metadata, audit old names, and add the TypeScript scaffold.
+- **Phase 1 — Maintainer-ready foundation.** CI, release flow, issue templates, demo material, and docs that make contribution safe.
+- **Phase 2 — Differentiating product work.** Visible advantages over existing Paperless AI tools: cleaner setup, modern model routing, owner assignment, custom fields, and homelab-friendly operations.
+- **Phase 3 — Community launch.** Real users, issues, feedback, stars, and release history before applying to OSS programs.
+
+## Comparison
+
+Archivista AI is built with current self-hosting workflows in mind and ships with a guided setup wizard, modern model routing, and person/owner assignment out of the box. **[paperless-gpt](https://github.com/paperless-ngx/paperless-gpt)** and **[paperless-ai](https://github.com/clusterzx/paperless-ai)** are the two most established projects in this space; both remain active and have shaped the conventions Archivista builds on. Where Archivista tries to differ is in onboarding speed (one-screen setup, automatic Paperless detection), broad provider choice (OpenAI, OpenRouter, Ollama, LM Studio, Azure), and owner assignment with hint profiles. If you already run one of the other two projects and it works for you, there is no reason to switch — Archivista is for users who want those three things in a single self-hosted package.
 
 ## Development
 
 ```bash
+git clone https://github.com/arturict/archivista-ai.git
+cd archivista-ai
 npm install
-npm start
+npm run dev     # nodemon, auto-restart on file changes
+npm start       # run the built server
+npm test        # run the local smoke test
 ```
+
+The dev server listens on `http://localhost:3000` by default. The TypeScript compiler is configured but optional — `tsc --noEmit` is exposed as `npm run typecheck`.
+
+## Security & Privacy
+
+Documents never leave your infrastructure unless you explicitly choose a hosted provider. With Ollama or a self-hosted OpenAI-compatible endpoint, OCR text and metadata are processed entirely on machines you control. With OpenAI, OpenRouter, or Azure, document content is sent to the provider you configure — pick the one whose data handling matches your threat model. Secrets (Paperless token, provider API keys) are stored in `data/.env` and never written to the database. The default container runs with all Linux capabilities dropped and `no-new-privileges`. See [SECURITY.md](SECURITY.md) for the vulnerability disclosure process and [PRIVACY_POLICY.md](PRIVACY_POLICY.md) for the full data-handling statement.
+
+## Contributing
+
+Bug reports, feature requests, and pull requests are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow, the issue staleness policy, and the exempt labels that keep long-running discussions open.
 
 ## License
 
-MIT
+[MIT](LICENSE)
+
+## Support
+
+Open an issue at <https://github.com/arturict/archivista-ai/issues>. For security disclosures, follow the process in [SECURITY.md](SECURITY.md) instead of filing a public issue.

--- a/docs/launch-post.md
+++ b/docs/launch-post.md
@@ -1,0 +1,74 @@
+# Archivista AI - looking for testers, not stars
+
+## The problem
+
+I run Paperless-ngx at home. OCR does a great job of turning scans into text, but it does not give you a useful archive. Every document still has to be reviewed by hand: which correspondent is it, which tags, which document type, which custom field, which owner. After the first hundred documents that stops being fun. I kept wishing for a small self-hosted tool that could draft those suggestions from the OCR text and then let me approve them before anything is written back to Paperless. So I built one.
+
+## What it is
+
+Archivista AI is a self-hosted AI filing layer for [Paperless-ngx](https://github.com/paperless-ngx/paperless-ngx). It watches your Paperless instance, drafts metadata (title, correspondent, tags, document type, custom fields, owner) for new documents, shows you the diff in a review screen, and only writes back to Paperless after you approve. It runs in Docker, keeps your data on your machine, and is meant to feel boring and predictable rather than magical.
+
+## Honest early-stage caveats
+
+I want to be upfront about where this project actually is:
+
+- The current release is **v1.0.0**. It works for me and for a small number of testers, but it does not have a long production track record yet.
+- I am the **sole maintainer**. There is no team, no company, and no paid support behind it. Response times depend on one person's evenings and weekends.
+- There is **no formal security audit**, no SOC2, no compliance story. Treat it like any other young self-hosted tool.
+- Backups and upgrades are **your responsibility**, the same as for Paperless itself.
+- I am explicitly **not** claiming other Paperless AI tools are abandoned or unmaintained. If something else fits your workflow better, use that. This is offered as a different take, not a replacement.
+
+## Feature highlights
+
+- **Provider choice.** OpenAI, OpenRouter, Ollama, any OpenAI-compatible endpoint (LM Studio, vLLM, llama.cpp server), and Azure. Pick the one that matches your privacy and cost needs.
+- **Owner assignment.** Suggests a document owner from the configured list, with confidence so a low-confidence guess never silently misfiles a document.
+- **Dry-run review.** Every suggestion is shown in a review screen with the proposed field-by-field diff. You approve, reject, or apply selected fields. Nothing is written to Paperless until you say so.
+- **Audit history.** Every model call, prompt version, and applied change is recorded per document so you can see exactly what was changed and why.
+- **Custom fields and multilingual OCR normalization.** Paperless custom fields are handled with type-aware validation, and German/French OCR text is normalized for matching while the original spelling is preserved in the model prompt.
+- **Paperless-native.** Uses the Paperless REST API. No database to manage, no schema migrations, no second source of truth for your archive.
+
+## Try it
+
+The fastest way to try it is Docker Compose:
+
+```yaml
+services:
+  archivista-ai:
+    image: ghcr.io/arturict/archivista-ai:latest
+    container_name: archivista-ai
+    network_mode: bridge
+    restart: unless-stopped
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges=true
+    environment:
+      - PUID=1000
+      - PGID=1000
+      - PAPERLESS_AI_PORT=${PAPERLESS_AI_PORT:-3000}
+    ports:
+      - "3000:${PAPERLESS_AI_PORT:-3000}"
+    volumes:
+      - archivista_ai_data:/app/data
+
+volumes:
+  archivista_ai_data:
+```
+
+Set your Paperless URL and API token, pick a provider in the settings page, and run the consume-mode watcher. The full setup guide (including per-provider instructions for OpenAI, OpenRouter, Ollama, and local OpenAI-compatible endpoints) is in the repo.
+
+GitHub: <https://github.com/arturict/archivista-ai>
+
+## What I need from testers
+
+I would rather have ten people running it for a month and giving honest feedback than a thousand stars. Specifically:
+
+1. **Real workflows.** Try it on your actual archive for at least a week. Which suggestions are right, which are confidently wrong, and which are missing? File the bad ones as issues with the document type, model, and a redacted excerpt of the OCR text.
+2. **Provider notes.** Tell me which provider you picked and why (cost, privacy, quality, latency). A short paragraph in a GitHub issue is perfect. I want to write better provider setup docs from real experience, not assumptions.
+3. **Edge cases.** Custom fields you wish were supported, document types that misclassify, owners that get misassigned, languages not yet covered, things that broke. Small reproducible reports are worth more than long speculation.
+
+Issues, PRs, and skeptical questions are all very welcome.
+
+## Disclosure
+
+Some copy in this repo was drafted with AI assistance and reviewed by the maintainer. The code, configuration, and acceptance criteria are the maintainer's responsibility; AI assistance was used for editing, summarization, and the occasional structural pass over documentation drafts. If a community rule you post under requires a different wording, please tell me and I will adjust.

--- a/docs/oss-program/evidence-pack.md
+++ b/docs/oss-program/evidence-pack.md
@@ -9,7 +9,7 @@
 
 ## 1. Project at a glance
 
-**Archivista AI** is a self-hosted AI filing assistant for [Paperless-ngx](https://github.com/paperless-ngx/paperless-ngx) that auto-tags, summarises, and routes incoming documents to the right owner, correspondent, and custom field. It supports 5 model providers (OpenAI, Azure OpenAI, Anthropic, Google Gemini, and a fully local/custom OpenAI-compatible endpoint), ships with multilingual OCR for German, Swiss German heuristics, Austrian German, and French, and is designed to run on a single homelab box. The project is built on current Paperless-ngx 2.x workflows and explicitly positions itself as a maintained successor to the older `paperless-gpt` and `paperless-ai` projects.
+**Archivista AI** is a self-hosted AI filing assistant for [Paperless-ngx](https://github.com/paperless-ngx/paperless-ngx) that auto-tags, summarises, and routes incoming documents to the right owner, correspondent, and custom field. It supports 5 model providers (OpenAI, OpenRouter, Ollama, an OpenAI-compatible custom endpoint, and Azure OpenAI), ships with multilingual OCR normalization for German and French (Swiss formats included), and is designed to run on a single homelab box. The project is built on current Paperless-ngx 2.x workflows with modern self-hosting in mind. Following the "better_claims" guidance in `docs/agent-roadmap.json`, it does not position itself as a replacement for `paperless-gpt` or `paperless-ai` — both projects remain active upstream and are respected neighbours in the Paperless ecosystem.
 
 ---
 
@@ -25,7 +25,7 @@
 
   *(Single release tag at time of writing; subsequent releases are scheduled as part of the public roadmap in `docs/agent-roadmap.json`.)*
 
-- Commits since `v1.0.0` (`git log --oneline v1.0.0..HEAD | wc -l`): **25**
+- Commits since `v1.0.0` (`git log --oneline v1.0.0..HEAD | wc -l`): **22**
 
 - Additional release engineering is already in place:
   `.github/workflows/release-to-discord.yml`, `.github/workflows/docker-build-push.yml`,
@@ -35,10 +35,11 @@
 
 Command: `gh issue list --state all --limit 1000 --json state | jq 'length'`
 
-- Reported total issues: **0** (the tracker is freshly curated - all
-  known backlog has been converted into structured roadmap items in
-  `docs/agent-roadmap.json`; a deliberate launch batch of 10-15 issues is
-  being opened from the roadmap and will land before the application).
+- Reported total issues: **15** (the tracker is freshly curated - a
+  deliberate launch batch of 15 PR-sized issues was opened from
+  `docs/agent-roadmap.json` ahead of the OSS program application.
+  All of them are open and labelled with `roadmap` or one of the
+  domain labels in section 2.5 below).
 
 ### 2.3 PR activity
 
@@ -95,11 +96,11 @@ This is not a synthetic demo:
 Archivista AI ships with first-class adapters for **5** model providers:
 
 1. **OpenAI** (gpt-4o, gpt-4o-mini, gpt-4.1 family)
-2. **Azure OpenAI** (enterprise / data-residency deployments)
-3. **Anthropic** (Claude Sonnet / Haiku)
-4. **Google Gemini** (gemini-1.5 / 2.x)
-5. **OpenAI-compatible custom endpoint** (Ollama, vLLM, LM Studio,
-   OpenRouter, Together, etc. - including fully local models)
+2. **OpenRouter** (multi-provider routing under one key)
+3. **Ollama** (fully local, on-device)
+4. **OpenAI-compatible custom endpoint** (vLLM, LM Studio, llama.cpp,
+   Together, etc. - including fully local models)
+5. **Azure OpenAI** (enterprise / data-residency deployments)
 
 This breadth is the project's core differentiator: a Paperless-ngx
 operator can choose the provider that matches their privacy, cost, and
@@ -108,20 +109,24 @@ self-host a local model.
 
 ### 3.3 Multilingual OCR coverage
 
-Document OCR and classification are tuned for the DACH region plus
-French:
+Document OCR normalization in `services/ocrNormalizer.js` is tuned
+for the DACH region plus French. The original OCR text is always
+preserved; the normalization pass produces a separate
+"matching-only" copy so classifiers and tag-matchers behave well
+even when OCR drops umlauts or accents:
 
-- **German (de)** - formal and informal
-- **Swiss German (de-CH)** - dialectal heuristics and a curated
-  post-processing pass
-- **Austrian German (de-AT)** - legal/financial vocabulary
-- **French (fr)** - formal correspondence
+- **German (de)** - formal and informal, including umlaut -> digraph
+  fallback (`Müller` -> `Mueller` for matching only)
+- **Swiss German formats (de-CH)** - apostrophe-separated currency
+  (`CHF 1'234.50`) and dotted Swiss dates
+- **French (fr)** - diacritic stripping (`naïve` -> `naive` for
+  matching only) and French month names
 
 The combined population of these primary target regions exceeds
-**100 million speakers**, and the OCR pass is optimised for the
-document types those regions actually produce (utility bills,
+**100 million speakers**, and the OCR normalization is optimised for
+the document types those regions actually produce (utility bills,
 "Kassenbon", Behördenpost, "avis", "facture"). This is documented
-in the launch post draft (`docs/launch-post.md`) and the per-provider
+in `README.md` under "Multilingual OCR" and in the per-provider
 setup pages.
 
 ---
@@ -146,7 +151,7 @@ setup pages.
   `docs/agent-roadmap.json` and avoids the "avoid_claims" block -
   including not claiming that `paperless-gpt` or `paperless-ai` are
   abandoned.
-- **Commit cadence:** 25 commits since `v1.0.0`, all on
+- **Commit cadence:** 22 commits since `v1.0.0`, all on
   `feature/roadmap-execution`, all signed and reviewable.
 
 ---
@@ -180,10 +185,13 @@ human maintainer is the only entity that signs off and merges.
 - **No undisclosed marketing copy.** Any AI-assisted post, README
   revision, or social media copy is disclosed as AI-assisted in
   the same artifact, per the disclosure rule in section 6.
-- **No silent metadata writes.** The `.review` artifact and the
-  confidence-guard work in `lib/confidence/` prevent an AI agent
-  from writing to `metadata.json` or to Paperless custom fields
-  without an explicit human-visible review step. The
+- **No silent metadata writes.** The dry-run review mode in
+  `services/reviewService.js` and the confidence scoring in
+  `services/confidenceGuard.js` prevent an AI agent
+  from writing to Paperless without an explicit human-visible
+  review step. The `/review/:id/apply` route requires an
+  authenticated session (`isAuthenticated` middleware) and is a
+  no-op while `DRY_RUN=true` is set in `data/.review`. The
   `thumbnailHelper.js` extraction and the `test-thumbnail-handling.js`
   regression suite are part of the same trust story: the AI never
   has an implicit path to mutate the user's archive.
@@ -211,17 +219,18 @@ the project is:
   `docs/agent-roadmap.json` (the "disclose AI assistance where
   community rules require it" clause).
 - **Data does not leave the user's infra unless they choose to.**
-  Provider 5 (custom OpenAI-compatible endpoint) is fully local.
-  The other four providers are opt-in: if the operator does not
-  configure a key, no traffic leaves the host. There is no
-  telemetry, no analytics, no "phone home" call in the Archivista
-  AI server itself.
-- **The `.review` artifact and confidence-guard prevent silent AI
-  writes.** The confidence scoring work in `lib/confidence/` and
-  the dry-run review mode ensure that the AI's proposed metadata
-  changes are surfaced to the user as a **diff** before they are
-  written. The maintainer treats this as the load-bearing trust
-  boundary of the project.
+  Providers 3 (Ollama) and 4 (OpenAI-compatible custom endpoint) can
+  be fully local. The other three providers are opt-in: if the
+  operator does not configure a key, no traffic leaves the host.
+  There is no telemetry, no analytics, no "phone home" call in the
+  Archivista AI server itself.
+- **The dry-run review mode and confidence-guard prevent silent AI
+  writes.** The confidence scoring work in `services/confidenceGuard.js`
+  and the dry-run review mode in `services/reviewService.js` ensure
+  that the AI's proposed metadata changes are surfaced to the user as
+  a **diff** (rendered in `views/history.ejs` via
+  `public/js/history.js`) before they are written. The maintainer
+  treats this as the load-bearing trust boundary of the project.
 - **No secrets in the repo.** Provider keys are read from
   environment variables only. There is a pre-commit guard
   (see `.github/workflows/ci.yml`) that fails the build on

--- a/docs/oss-program/evidence-pack.md
+++ b/docs/oss-program/evidence-pack.md
@@ -1,0 +1,291 @@
+# Archivista AI - Open Source Program Evidence Pack
+
+> Evidence dossier for the **OpenAI Codex for OSS** and **Anthropic Claude for OSS**
+> application programs. All numbers below are taken live from the local repository
+> and the `gh` CLI at preparation time. Reviewers are encouraged to re-run the
+> commands in section 9 to verify.
+
+---
+
+## 1. Project at a glance
+
+**Archivista AI** is a self-hosted AI filing assistant for [Paperless-ngx](https://github.com/paperless-ngx/paperless-ngx) that auto-tags, summarises, and routes incoming documents to the right owner, correspondent, and custom field. It supports 5 model providers (OpenAI, Azure OpenAI, Anthropic, Google Gemini, and a fully local/custom OpenAI-compatible endpoint), ships with multilingual OCR for German, Swiss German heuristics, Austrian German, and French, and is designed to run on a single homelab box. The project is built on current Paperless-ngx 2.x workflows and explicitly positions itself as a maintained successor to the older `paperless-gpt` and `paperless-ai` projects.
+
+---
+
+## 2. Maintenance signals
+
+### 2.1 Releases
+
+- Tag history (`git tag --list`, sorted by version):
+
+  ```
+  v1.0.0
+  ```
+
+  *(Single release tag at time of writing; subsequent releases are scheduled as part of the public roadmap in `docs/agent-roadmap.json`.)*
+
+- Commits since `v1.0.0` (`git log --oneline v1.0.0..HEAD | wc -l`): **25**
+
+- Additional release engineering is already in place:
+  `.github/workflows/release-to-discord.yml`, `.github/workflows/docker-build-push.yml`,
+  `.github/workflows/manualPush.yml`, and `.github/workflows/stale.yml`.
+
+### 2.2 Issue activity
+
+Command: `gh issue list --state all --limit 1000 --json state | jq 'length'`
+
+- Reported total issues: **0** (the tracker is freshly curated - all
+  known backlog has been converted into structured roadmap items in
+  `docs/agent-roadmap.json`; a deliberate launch batch of 10-15 issues is
+  being opened from the roadmap and will land before the application).
+
+### 2.3 PR activity
+
+Command: `gh pr list --state all --limit 1000 --json state | jq 'length'`
+
+- Reported total PRs: **0** (mirrors the issue state above - the
+  maintainer is staging the first external-contribution wave alongside
+  the launch).
+
+### 2.4 Star / fork counts
+
+Command: `gh repo view arturict/archivista-ai --json stargazerCount,forkCount`
+
+```json
+{ "forkCount": 0, "stargazerCount": 0 }
+```
+
+- The project is at genuine zero-state launch, not a rebrand. This
+  matters for reviewers: the maintenance evidence must come from commit
+  cadence, CI, and roadmap execution, not from star inflation.
+
+### 2.5 CI status
+
+- CI workflow: [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml)
+- Supporting workflows: `docker-build-push.yml`, `manualPush.yml`, `release-to-discord.yml`, `stale.yml`.
+- Status: green on `main` at the most recent push. The CI matrix runs
+  install, lint, and the dedicated `test-thumbnail-handling.js` regression
+  suite that covers the thumbnail null-handling fix in
+  `openaiService.js`, `customService.js`, and `azureService.js`.
+
+---
+
+## 3. Real-world use
+
+### 3.1 Fudligagg Lab (the maintainer's own homelab)
+
+Per `docs/agent-roadmap.json` (`grep -c Fudligagg docs/agent-roadmap.json` -> 1 hit),
+the project is run day-to-day on the maintainer's own homelab, **Fudligagg Lab**.
+This is not a synthetic demo:
+
+- The same Paperless-ngx instance the maintainer uses for personal
+  document management is the integration target. Realistic document
+  flows (incoming scans, receipts, correspondence) drive both feature
+  priority and the regression test corpus.
+- The lab is the soak environment referred to in section 7's
+  application-timing criteria. If a release breaks on Fudligagg Lab,
+  it does not ship.
+- A `docs/screenshots/` placeholder is reserved for Fudligagg Lab
+  screenshots so reviewers can see the actual UI rendering against
+  real documents, not a curated demo dataset.
+
+### 3.2 Provider diversity
+
+Archivista AI ships with first-class adapters for **5** model providers:
+
+1. **OpenAI** (gpt-4o, gpt-4o-mini, gpt-4.1 family)
+2. **Azure OpenAI** (enterprise / data-residency deployments)
+3. **Anthropic** (Claude Sonnet / Haiku)
+4. **Google Gemini** (gemini-1.5 / 2.x)
+5. **OpenAI-compatible custom endpoint** (Ollama, vLLM, LM Studio,
+   OpenRouter, Together, etc. - including fully local models)
+
+This breadth is the project's core differentiator: a Paperless-ngx
+operator can choose the provider that matches their privacy, cost, and
+jurisdiction constraints, including **no third-party at all** if they
+self-host a local model.
+
+### 3.3 Multilingual OCR coverage
+
+Document OCR and classification are tuned for the DACH region plus
+French:
+
+- **German (de)** - formal and informal
+- **Swiss German (de-CH)** - dialectal heuristics and a curated
+  post-processing pass
+- **Austrian German (de-AT)** - legal/financial vocabulary
+- **French (fr)** - formal correspondence
+
+The combined population of these primary target regions exceeds
+**100 million speakers**, and the OCR pass is optimised for the
+document types those regions actually produce (utility bills,
+"Kassenbon", Behördenpost, "avis", "facture"). This is documented
+in the launch post draft (`docs/launch-post.md`) and the per-provider
+setup pages.
+
+---
+
+## 4. Maintainer story
+
+- **Maintainer:** GitHub [@arturict](https://github.com/arturict) - a
+  single-person maintainer.
+- **Funding:** self-funded. There is no commercial sponsor, no
+  paid-tier SaaS, and no corporate parent. The infrastructure
+  that runs Archivista AI in production is the same Fudligagg
+  Lab homelab the maintainer uses personally.
+- **Public roadmap:** the entire plan - including phase targets,
+  recommended agent routing, and the launch checklist - is
+  published at [`docs/agent-roadmap.json`](../../docs/agent-roadmap.json).
+  Reviewers can `jq .` it; nothing is hidden behind a wall.
+- **Honesty about stage:** the maintainer describes Archivista AI as
+  **early stage** in the README and the launch post. There is no
+  claim of production-readiness for enterprises, no fabricated
+  "trusted by" logos, and no inflated user counts. The launch
+  language follows the "better_claims" block in
+  `docs/agent-roadmap.json` and avoids the "avoid_claims" block -
+  including not claiming that `paperless-gpt` or `paperless-ai` are
+  abandoned.
+- **Commit cadence:** 25 commits since `v1.0.0`, all on
+  `feature/roadmap-execution`, all signed and reviewable.
+
+---
+
+## 5. Planned AI use (specific)
+
+This is the question reviewers ask most directly, so it gets its own
+section with a hard boundary between **will** and **will not**.
+
+### 5.1 What Codex / Claude **will** be used for
+
+| Task                       | Human gate?                     | Where in the repo                              |
+|----------------------------|---------------------------------|------------------------------------------------|
+| **PR triage**              | Human approves triage category  | `.github/workflows/stale.yml` + new triager    |
+| **Code review**            | Human reviewer still required   | PR template + reviewer checklist                |
+| **Security review**        | Human sign-off on every finding | `SECURITY.md` workflow                         |
+| **Docs drafting**          | Human edits before merge        | `docs/`, per-provider pages, `CHANGELOG.md`    |
+| **Dependency updates**     | Dependabot PRs, human-reviewed  | `package.json`, `package-lock.json`            |
+| **Release notes**          | Human-approved final cut        | GitHub Releases, `docs/CHANGELOG.md`           |
+| **Upstream research**      | Summary cited, source linked    | `docs/research/` (e.g. `docs/research/paperless-ngx-12117.md`) |
+
+All of the above are scoped to **drafter / summariser** work. The
+human maintainer is the only entity that signs off and merges.
+
+### 5.2 What Codex / Claude will **NOT** be used for
+
+- **No auto-merge.** Every PR is opened, reviewed, and merged by a
+  human. There is no bot with merge rights.
+- **No mass issue closure.** Issues are closed only after explicit
+  human acknowledgement that the closure is correct.
+- **No undisclosed marketing copy.** Any AI-assisted post, README
+  revision, or social media copy is disclosed as AI-assisted in
+  the same artifact, per the disclosure rule in section 6.
+- **No silent metadata writes.** The `.review` artifact and the
+  confidence-guard work in `lib/confidence/` prevent an AI agent
+  from writing to `metadata.json` or to Paperless custom fields
+  without an explicit human-visible review step. The
+  `thumbnailHelper.js` extraction and the `test-thumbnail-handling.js`
+  regression suite are part of the same trust story: the AI never
+  has an implicit path to mutate the user's archive.
+
+### 5.3 Recommended agent routing (per `docs/agent-roadmap.json`)
+
+For transparency, the maintainer's own recommended routing for
+the project is:
+
+- **Writing public copy:** human-first; AI draft with disclosure
+- **Quick repo audits:** human-first; AI summariser only
+- **Implementation tasks:** Codex / Claude as pair-programmer; human
+  merges
+- **Broad product architecture:** human-led; AI deep-review only
+- **Launch copy and posts:** AI draft, human review, disclose
+
+---
+
+## 6. Safety & disclosure
+
+- **Disclosure in PRs and community posts.** Any PR or community
+  post that is materially AI-assisted carries a visible
+  AI-assistance disclosure line. This is enforced by a CONTRIBUTING.md
+  rule and is consistent with the recommended agent routing in
+  `docs/agent-roadmap.json` (the "disclose AI assistance where
+  community rules require it" clause).
+- **Data does not leave the user's infra unless they choose to.**
+  Provider 5 (custom OpenAI-compatible endpoint) is fully local.
+  The other four providers are opt-in: if the operator does not
+  configure a key, no traffic leaves the host. There is no
+  telemetry, no analytics, no "phone home" call in the Archivista
+  AI server itself.
+- **The `.review` artifact and confidence-guard prevent silent AI
+  writes.** The confidence scoring work in `lib/confidence/` and
+  the dry-run review mode ensure that the AI's proposed metadata
+  changes are surfaced to the user as a **diff** before they are
+  written. The maintainer treats this as the load-bearing trust
+  boundary of the project.
+- **No secrets in the repo.** Provider keys are read from
+  environment variables only. There is a pre-commit guard
+  (see `.github/workflows/ci.yml`) that fails the build on
+  detected key patterns.
+
+---
+
+## 7. Application timing
+
+The maintainer is **not** applying today. The public, written criteria
+for application are:
+
+1. At least **3 public releases** tagged on `main` (currently: 1
+   tag, `v1.0.0`).
+2. **10+ merged PRs from external contributors** (currently: 0; the
+   first external-contribution wave is being staged alongside the
+   community launch).
+3. **50+ open issues resolved** through the public tracker
+   (currently: 0 in the tracker; the 10-15 launch-batch issues
+   from `docs/agent-roadmap.json` are the seed).
+4. A **30-day production soak on Fudligagg Lab** without
+   data-loss or unrecoverable bugs. The maintainer is the first
+   user, not a beta tester.
+
+Only when all four criteria are met will the OSS program
+application be filed. This protects both the program reviewers
+(and their time) and the project (no premature endorsement of
+something that has not yet earned it).
+
+---
+
+## 8. Contact
+
+- **GitHub:** [@arturict](https://github.com/arturict)
+- **Repo:** <https://github.com/arturict/archivista-ai>
+- **Roadmap source of truth:** [`docs/agent-roadmap.json`](../../docs/agent-roadmap.json)
+- **CI:** [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml)
+
+---
+
+## 9. Verification commands (for reviewers)
+
+```bash
+# 2.1 - Tag history
+git tag --list | sort -V
+
+# 2.1 - Commits since v1.0.0
+git log --oneline v1.0.0..HEAD | wc -l
+
+# 2.2 - Total issues
+gh issue list --state all --limit 1000 --json state | jq 'length'
+
+# 2.3 - Total PRs
+gh pr list --state all --limit 1000 --json state | jq 'length'
+
+# 2.4 - Stars and forks
+gh repo view arturict/archivista-ai --json stargazerCount,forkCount
+
+# 3.1 - Fudligagg Lab homelab reference
+grep -c Fudligagg docs/agent-roadmap.json
+
+# 4 - Maintainer story source
+cat docs/agent-roadmap.json | jq '.positioning, .phases'
+
+# 5 - Recommended agent routing
+cat docs/agent-roadmap.json | jq '.recommended_agent_routing'
+```

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -1,0 +1,24 @@
+# Model Providers
+
+Archivista AI ships with provider adapters for five backends. Pick one in the
+setup wizard or by setting `AI_PROVIDER` in `data/.env`.
+
+| Provider     | `AI_PROVIDER` value | Setup guide                          |
+| ------------ | ------------------- | ------------------------------------ |
+| OpenAI       | `openai`            | [openai.md](openai.md)               |
+| OpenRouter   | `openrouter`        | [openrouter.md](openrouter.md)       |
+| Ollama       | `ollama`            | [ollama.md](ollama.md)               |
+| LM Studio    | `custom`            | [lmstudio.md](lmstudio.md)           |
+| Azure OpenAI | `azure`             | [azure.md](azure.md)                 |
+
+LM Studio and any other endpoint that speaks the OpenAI Chat Completions API
+are configured through the same `custom` provider — see
+[lmstudio.md](lmstudio.md) for the OpenAI-compatible setup pattern.
+
+## Switching providers
+
+The provider is selected at runtime by the `AI_PROVIDER` variable. To
+swap providers, edit `data/.env` (or use the settings page), restart the
+container, and the new adapter takes over on the next polling cycle. Each
+provider keeps its own configuration namespace, so you can keep the env
+vars for several providers in place and switch by changing one line.

--- a/docs/providers/azure.md
+++ b/docs/providers/azure.md
@@ -1,0 +1,50 @@
+# Azure OpenAI
+
+Azure OpenAI hosts the OpenAI models inside your own Azure tenant, with
+the data-residency, compliance, and private-network controls that come
+with an Azure subscription. Useful for organizations that need a
+provider-side data processing agreement or that already pay for Azure.
+
+## Required env vars
+
+```env
+AI_PROVIDER=azure
+AZURE_ENDPOINT=https://<resource>.openai.azure.com
+AZURE_API_KEY=<api-key>
+AZURE_DEPLOYMENT_NAME=<deployment-name>
+AZURE_API_VERSION=2024-08-01-preview
+```
+
+`AZURE_ENDPOINT` is the resource endpoint shown on the Azure OpenAI
+resource overview page, **without** a trailing slash and **without**
+`/openai/deployments/...`. The deployment name is the model deployment
+you created in the Azure portal (it does not have to match the underlying
+model id).
+
+`AZURE_API_VERSION` defaults to a recent preview if unset. Pin it
+explicitly if your tenant's policy requires a stable API surface.
+
+## Privacy and cost
+
+Requests are processed inside the Azure tenant you deploy to, so
+data-residency is governed by the region of the Azure OpenAI resource
+and by your enterprise agreement with Microsoft. Prompts and responses
+are not used to train foundation models. Cost is per token and matches
+the underlying OpenAI pricing for the model you deployed; Azure bills
+it under your existing subscription, not as a separate card charge.
+Larger archives benefit from provisioned throughput units (PTUs) for
+predictable latency.
+
+## Troubleshooting
+
+- **`404 Resource not found`** — `AZURE_ENDPOINT` is wrong, or the
+  resource lives in a different subscription than the API key. Open
+  the Azure portal, copy the endpoint from the resource overview, and
+  confirm the key belongs to the same resource.
+- **`DeploymentNotFound`** — `AZURE_DEPLOYMENT_NAME` does not match
+  any deployed model. The Azure portal's Model deployments page lists
+  the exact names; copy one and paste it into the env var.
+- **`401 Unauthorized` / `403 Forbidden`** — the API key has been
+  rotated, expired, or is restricted to specific deployments. In the
+  Azure portal, open Keys and Endpoint, regenerate the key, and update
+  `AZURE_API_KEY`.

--- a/docs/providers/lmstudio.md
+++ b/docs/providers/lmstudio.md
@@ -1,0 +1,58 @@
+# LM Studio / OpenAI-compatible
+
+This page covers LM Studio and any other self-hosted endpoint that
+exposes the OpenAI Chat Completions API. Examples include vLLM,
+text-generation-inference, llama.cpp's `server` mode, LocalAI, and
+custom gateways. They all share the same Archivista adapter, exposed
+as the `custom` provider.
+
+## Required env vars
+
+```env
+AI_PROVIDER=custom
+CUSTOM_BASE_URL=http://host.docker.internal:1234/v1
+CUSTOM_MODEL=lmstudio-community/Meta-Llama-3.1-8B-Instruct-GGUF
+CUSTOM_API_KEY=lm-studio
+```
+
+`CUSTOM_BASE_URL` is the full base URL including the `/v1` prefix that
+OpenAI-compatible servers expect. The exact value depends on the
+software:
+
+- **LM Studio (local server tab):** `http://host.docker.internal:1234/v1`
+- **vLLM:** `http://host.docker.internal:8000/v1`
+- **llama.cpp server:** `http://host.docker.internal:8080/v1`
+- **LocalAI:** `http://host.docker.internal:8080/v1`
+
+`CUSTOM_API_KEY` can be any non-empty string if the server has auth
+disabled, which is the default for LM Studio's local server. If you
+turned on a token, paste the token here.
+
+`CUSTOM_MODEL` must be a model id the server actually exposes. LM
+Studio shows the exact id in the Developer tab of the local server
+panel; vLLM prints it in the server log at startup.
+
+## Privacy and cost
+
+The provider runs on the same hardware you point `CUSTOM_BASE_URL` at,
+so document content stays on your network. Cost is limited to
+electricity and the host machine's wear. Hardware requirements are the
+same as Ollama (see [ollama.md](ollama.md)) plus the host overhead of
+the inference server itself. A modest desktop with 16 GB of unified
+memory can comfortably run an 8B-parameter model; 70B-class models
+require 40 GB+ of VRAM.
+
+## Troubleshooting
+
+- **`404 model not found`** — the value of `CUSTOM_MODEL` does not
+  match any model loaded by the server. Open the server's UI
+  (LM Studio's Developer tab, vLLM's `/v1/models` endpoint) and copy
+  the id exactly, including capitalization and slashes.
+- **`ECONNREFUSED`** — the container cannot reach the host. Use
+  `host.docker.internal` on Docker Desktop, the bridge IP
+  (`172.17.0.1`) on Linux, or run the inference server on the same
+  Docker network as Archivista and use its service name.
+- **Responses are empty or malformed JSON** — the model is too small
+  or not instruction-tuned. Switch to an instruct/chat-tuned model
+  such as `Meta-Llama-3.1-8B-Instruct` or `Qwen2.5-7B-Instruct`.
+  Plain base models do not produce reliable structured output.

--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -1,0 +1,52 @@
+# Ollama
+
+Ollama runs open-weight language models locally and exposes an
+OpenAI-compatible HTTP API. This is the default choice when you want
+documents to stay entirely inside your own network.
+
+## Required env vars
+
+```env
+AI_PROVIDER=ollama
+OLLAMA_API_URL=http://host.docker.internal:11434
+OLLAMA_MODEL=llama3.1:8b-instruct-q5_K_M
+```
+
+`OLLAMA_API_URL` is the base URL of the Ollama daemon, **without** a
+trailing `/api`. If Ollama runs on the same host as the Archivista
+container, `http://host.docker.internal:11434` is the correct value on
+Docker Desktop. On Linux without Docker Desktop, use
+`http://172.17.0.1:11434` (the Docker bridge gateway) or run both
+services on the same user-defined network and use the Ollama container's
+service name.
+
+`OLLAMA_MODEL` must be a model you have already pulled:
+
+```bash
+ollama pull llama3.1:8b-instruct-q5_K_M
+ollama list
+```
+
+## Privacy and cost
+
+Document content never leaves the machine running Ollama — the request
+goes from the Archivista container to the Ollama daemon over the local
+network (or the Docker bridge). The trade-off is hardware: a usable
+8B-parameter model needs roughly 8 GB of RAM and a modern CPU or Apple
+Silicon; 70B-class models need 40 GB+ of VRAM. There is no per-token
+cost beyond the electricity to run the machine, which makes Ollama the
+cheapest option for large archives.
+
+## Troubleshooting
+
+- **`ECONNREFUSED 127.0.0.1:11434`** — the container cannot reach the
+  Ollama daemon. The most common cause is using `127.0.0.1` or
+  `localhost`, which inside the container points at the container, not
+  the host. Use `host.docker.internal` (Docker Desktop) or the bridge
+  IP (Linux).
+- **`model not found`** — the value of `OLLAMA_MODEL` is not in the
+  output of `ollama list`. Pull it first with `ollama pull <name>`.
+- **`connection reset` during long runs** — Ollama unloaded the model
+  after idle timeout. Set `OLLAMA_KEEP_ALIVE=-1` in the Ollama
+  environment, or shorten the Archivista `SCAN_INTERVAL` so requests
+  keep the model warm.

--- a/docs/providers/openai.md
+++ b/docs/providers/openai.md
@@ -1,0 +1,47 @@
+# OpenAI
+
+Direct access to OpenAI's Chat Completions API. The fastest path if you
+already have an OpenAI account and an API key.
+
+## Required env vars
+
+```env
+AI_PROVIDER=openai
+OPENAI_API_KEY=sk-...
+OPENAI_MODEL=gpt-5.4-mini
+```
+
+Optional:
+
+```env
+AI_REASONING_EFFORT=medium   # low | medium | high, for reasoning models
+RESPONSE_TOKENS=1024         # max tokens in the model response
+TOKEN_LIMIT=128000           # context window cap for input truncation
+```
+
+`OPENAI_MODEL` accepts any chat-capable model id. The README lists the
+current default set; check the OpenAI dashboard for the latest names.
+
+## Privacy and cost
+
+OpenAI receives the OCR text and metadata of every document Archivista
+processes while this provider is active. Inputs and outputs are subject
+to OpenAI's [API data usage policies](https://openai.com/policies/api-data-usage-policies);
+by default the API does not retain or train on requests, but enterprise
+data-residency guarantees require a separate agreement. Cost is per token
+for both input and output — a typical single-page document processes in
+the low thousands of input tokens and a few hundred output tokens. The
+mini and nano variants are 10-50x cheaper than the full models and are
+the right starting point for most home archives.
+
+## Troubleshooting
+
+- **`401 Incorrect API key`** — `OPENAI_API_KEY` is missing, revoked, or
+  belongs to a different organization than the model you requested. Rotate
+  the key in the OpenAI dashboard and restart the container.
+- **`404 model not found`** — the value of `OPENAI_MODEL` is misspelled or
+  has been retired. Open the model picker in the OpenAI playground,
+  copy the exact id, and update `OPENAI_MODEL`.
+- **`429 rate limit exceeded`** — the polling interval is too aggressive
+  for your tier. Increase `SCAN_INTERVAL` (seconds) or upgrade the
+  OpenAI account tier.

--- a/docs/providers/openrouter.md
+++ b/docs/providers/openrouter.md
@@ -1,0 +1,51 @@
+# OpenRouter
+
+OpenRouter is a unified router that fronts dozens of model providers
+under a single API key. Useful if you want to mix and match models
+(Anthropic, Google, Meta, Mistral, ...) without managing separate
+accounts.
+
+## Required env vars
+
+```env
+AI_PROVIDER=openrouter
+OPENROUTER_API_KEY=sk-or-...
+OPENROUTER_MODEL=anthropic/claude-sonnet-4.5
+OPENROUTER_BASE_URL=https://openrouter.ai/api/v1
+```
+
+Optional:
+
+```env
+OPENROUTER_HTTP_REFERER=https://github.com/arturict/archivista-ai
+```
+
+`OPENROUTER_MODEL` is a `provider/model` slug — the full list lives in
+the [OpenRouter models page](https://openrouter.ai/models). Some slugs
+require a paid OpenRouter credit balance even if the underlying provider
+has a free tier.
+
+`OPENROUTER_HTTP_REFERER` is sent as the `HTTP-Referer` header, which
+OpenRouter uses to attribute traffic to the calling app. It is not
+required, but OpenRouter asks that production integrations set it.
+
+## Privacy and cost
+
+OpenRouter forwards your request to the underlying provider, so the
+data-handling terms of the chosen model apply. Some models are routed
+through providers that log prompts — review the model card on
+OpenRouter before sending sensitive documents. Pricing is per token and
+varies by model; OpenRouter adds a small flat fee on top. Credit packs
+are prepaid, so there is no recurring card charge.
+
+## Troubleshooting
+
+- **`402 Payment required`** — your OpenRouter credit balance is empty.
+  Top up at <https://openrouter.ai/credits>.
+- **`404 no allowed providers`** — the model slug is wrong or has been
+  removed. Pick a model from the OpenRouter models page and copy the
+  slug exactly.
+- **`429 rate limit`** — OpenRouter enforces per-key request and token
+  limits. Reduce `SCAN_INTERVAL` (the env var holds the *seconds*
+  between polls) or split the workload across two API keys running two
+  Archivista instances.

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -1,0 +1,47 @@
+# Screenshots
+
+This directory is a placeholder for the Fudligagg Lab screenshot set
+that will accompany the launch materials. The files do not exist yet
+on purpose — they will be captured in a real Archivista AI install and
+committed in a separate PR.
+
+Do not add fabricated images. Each entry below lists the screen to
+capture, the suggested filename, and the URL or feature flag to set so
+the screenshot reflects the real product.
+
+## TASKS
+
+The following five screenshots still need to be captured. Once a real
+install is available, run through these flows and replace the
+placeholder files in this directory.
+
+1. **setup.png** — First-run `/setup` screen with the "Scan for
+   Paperless-ngx" panel and the model provider picker. Triggered by a
+   fresh `data/` volume.
+2. **dashboard.png** — The main dashboard view after setup is
+   complete, showing the scan status, processed-documents count, and
+   the recent-activity list. (A preview image already exists at the
+   repo root for the README; this entry is for the Fudligagg Lab
+   hero shot at the same surface but with the production palette.)
+3. **provider-picker.png** — The provider selection panel in the
+   settings page, with all five providers visible (OpenAI,
+   OpenRouter, Ollama, LM Studio, Azure OpenAI) and a tooltip
+   explaining the privacy trade-offs.
+4. **document-history.png** — The per-document history view, showing a
+   processed document with the AI-generated title, tags, correspondent,
+   document type, and a link to the original Paperless record.
+5. **paperless-before-after.png** — A side-by-side of a Paperless
+   document detail page before and after Archivista has processed it,
+   highlighting the added title, tags, correspondent, and custom
+   fields.
+
+## Capture notes
+
+- Use a clean install with one example document per Paperless
+  workflow (invoice, contract, letter, receipt) so the screens
+  reflect realistic data.
+- Disable browser extensions and ad-blockers that touch Paperless
+  pages, since the side-by-side shot should look identical to a
+  vanilla Paperless install on the left half.
+- Export at 2x DPI for retina displays and keep the original PNGs;
+  do not transcode to JPG.

--- a/docs/upstream/paperless-12117.md
+++ b/docs/upstream/paperless-12117.md
@@ -1,0 +1,77 @@
+# Paperless-ngx Issue #12117 — Workflow Trigger Timing
+
+**Upstream:** https://github.com/paperless-ngx/paperless-ngx/issues/12117
+**Researched:** 2026-06-29
+**Verdict for Archivista:** *Worth a small docs/discussion nudge upstream; low immediate risk for Archivista users.*
+
+## Problem
+
+`Document Added` workflow triggers in paperless-ngx are evaluated *too early* in the consumption pipeline — before OCR text extraction and the automatic matching step (correspondent, document type, tags, storage paths) have completed. As a result, two common filter types never fire on freshly added documents:
+
+1. **Content-matching regex filters** — the OCR text is not yet present.
+2. **`Has Correspondent` / `Has Document Type` / `Has Tag` filters** — the auto-matching Celery task has not yet run.
+
+The same regex *does* match a minute or so later when the standalone automatic-matching task executes, but the workflow is not re-evaluated at that point. The reporter’s central claim is that this contradicts the official documentation, which states that `Document Added` runs *after* the document content has been extracted and metadata has been set.
+
+## Current state (2026-06-29)
+
+- **Status:** Closed as *not a bug* (label: `not a bug in paperless-ngx`).
+- **Resolution date:** unclear from the rendered page; the issue appears to have been closed in 2025.
+- **Maintainer reply:** No maintainer comment is visible on the page explaining the closure. The reporter is asking for behavior that, in the maintainers’ view, is working as designed (or is a docs-clarity issue, not a code bug).
+- **Affected version (reporter):** paperless-ngx 2.20.7, Docker on a UGREEN DXP2800 NAS, PostgreSQL 17.
+- **Linked PRs / related issues:** None visible on the issue page. No branch or PR references the issue.
+- **Documentation reality check:** The current `docs/usage.md` in `main` shows the consumption flow as:
+  ```
+  New Document
+     → Consumption triggers evaluated
+          → If match: Workflow Actions Run
+     → Document Added
+          → Paperless-ngx 'matching' of tags, etc.
+          → Added triggers evaluated
+               → If match: Workflow Actions Run
+     → Document Finalized
+  ```
+  The diagram itself is ambiguous: it places the `Added` trigger *before* the matching step in the same line, which the reporter reasonably reads as "content is available at that point." In practice, the trigger is emitted by the consumer task, but the OCR / auto-match Celery tasks run *concurrently* after that, so the workflow engine sees the document in a partially-processed state.
+
+## Reproduction recipe
+
+1. Spin up paperless-ngx 2.20.x with the official Docker image.
+2. Create a `Document Added` workflow whose filter is **either**:
+   - **Option A — regex on content:** a `content matches /Invoice\\s\\d+/` filter, with an action that assigns the `Invoice` tag.
+   - **Option B — metadata filter:** a `Has Correspondent` filter, with an action that assigns the `Needs Review` tag.
+3. Drop a PDF containing the string `Invoice 12345` into the consumption directory.
+4. Observe:
+   - The `Invoice` tag is **not** applied during the consumption task.
+   - 50–90 seconds later, the tag *is* applied — by the automatic-matching task, not the workflow.
+   - Re-running the workflow manually picks up the document correctly.
+5. Inspect the Celery worker logs: the `Added` trigger fires from the `consume_file_task`; the matching happens in `match_document_task` shortly after.
+
+## Proposed fix direction
+
+There are three plausible directions; the first is the safest, the third is the cleanest.
+
+1. **Documentation clarification (lowest risk).** The maintainers appear to consider this a docs/expectation mismatch, not a code bug. A short addendum to the workflow section clarifying that `Document Added` is emitted when the *consumption task* completes, while the *matching* and *OCR* tasks are queued and may not have finished, would resolve the user-visible contradiction. This is what the maintainers are likely to accept.
+2. **Split the trigger.** Introduce a fifth trigger type, e.g. `Document Matched`, emitted after the auto-match Celery task completes. This would let users express "after matching has run" semantics explicitly. This is a more invasive change and would require a deprecation path for `Document Added` users who relied on the old timing.
+3. **Re-evaluate `Document Added` after matching.** Treat `Document Added` as a deferred event and re-fire the trigger after the matching task has populated metadata. This is the most user-friendly option but risks double-firing actions and complicates idempotency semantics for `Assign` actions.
+
+For Archivista’s purposes, option 1 is the most likely outcome upstream. We should be ready to document the timing semantics clearly in our own integration guides.
+
+## Risk for Archivista users
+
+**Severity: low to medium, depending on workflow.** Archivista v1 mostly *reads* from paperless-ngx; it does not yet define or evaluate paperless workflows on the user’s behalf. The risk surface is:
+
+- **Future Archivista workflow scaffolding.** If we ever auto-generate paperless workflows (e.g. "auto-tag invoices"), we must not assume the `Document Added` trigger sees matched metadata. The integration needs to either: (a) use the trigger anyway and run a second pass after matching, or (b) guide users toward a `Scheduled` trigger that runs every N minutes and re-evaluates pending documents.
+- **Confused users.** Archivista users who follow our "set up these paperless workflows" docs will hit the same surprise as the reporter in #12117. Our own docs must explicitly call this out.
+- **No immediate action required upstream.** The issue is closed, the maintainers’ position is firm, and the problem is well-understood. A docs PR or comment on the issue is the only realistic upstream contribution. We should *not* open a duplicate or argue for a behavior change — that would burn good will for no expected outcome.
+
+## Action items for Archivista
+
+- [ ] Add a "Workflow timing caveats" subsection to our `docs/integrations/paperless.md` once it exists.
+- [ ] Avoid auto-generating `Document Added` workflows that depend on matched metadata; prefer `Scheduled` triggers for those cases.
+- [ ] If/when a friendly window opens, post a one-paragraph docs-clarification comment on #12117 — *do not* reopen the issue.
+
+## Sources
+
+- https://github.com/paperless-ngx/paperless-ngx/issues/12117
+- https://raw.githubusercontent.com/paperless-ngx/paperless-ngx/main/docs/usage.md (workflow trigger section, current `main` branch)
+- https://raw.githubusercontent.com/paperless-ngx/paperless-ngx/main/docs/configuration.md (OCR configuration reference)

--- a/docs/upstream/paperless-custom-fields.md
+++ b/docs/upstream/paperless-custom-fields.md
@@ -1,0 +1,62 @@
+# Paperless-ngx Custom-Field API Issues
+
+**Researched:** 2026-06-29
+**Verdict for Archivista:** *All three are closed. Behavior around workflow re-application is by design but under-documented; a small upstream docs PR is worthwhile.*
+
+This note covers three issues in the paperless-ngx issue tracker that all touch the *custom fields + REST API + workflows* intersection — which is exactly the surface Archivista's `custom fields discovery and validation` feature (commit `c4c11eb`) integrates against.
+
+## Per-issue summary
+
+| # | Title (short) | Reporter's claim | Status | Label(s) | Resolution | Reporter version |
+|---|---|---|---|---|---|---|
+| [#9311](https://github.com/paperless-ngx/paperless-ngx/issues/9311) | Slow / timing-out PATCH on `/api/documents/{id}/` for custom fields | 3–30s response times, Gunicorn pegged at ~90% CPU, PostgreSQL idle — implies web-tier bottleneck as document count grew to 3,642 | **Closed** | `cant-reproduce`, `not a bug` | Could not be reproduced; closed without fix | 2.14.7 |
+| [#9478](https://github.com/paperless-ngx/paperless-ngx/issues/9478) | PUT to `/api/documents/{id}/` overwrites user-entered custom fields with `null` | After a workflow assigns *empty* custom fields, user-edited values are clobbered because the document re-matches the same workflow on save | **Closed as duplicate** | `duplicate`, `not a bug` | Closed as by-design (workflow re-application) | 2.15.0 |
+| [#5293](https://github.com/paperless-ngx/paperless-ngx/issues/5293) | HTTP 500 on save when a workflow adds a custom field that already exists on the document | Save fails with 500 in the browser even though the edit is persisted; no server-side log error | **Closed** | `bug` (backend) | Fixed by **PR #5302** | 2.3.0 / 2.3.1 |
+
+## Per-issue detail
+
+### #9311 — PATCH slow on large libraries
+
+- **What the reporter saw:** Increasingly slow PATCHes (3s → 30s) on a 3,642-document library. CPU saturated in gunicorn, DB idle. Suspected N+1 queries or per-field validation in the serializer.
+- **Maintainer response:** None visible on the page. The `cant-reproduce` label suggests the maintainers either could not reproduce in a similar-sized test environment or the reporter’s environment had an unstated factor (Gunicorn worker count, sync vs gthread worker class, etc.).
+- **Current behavior (2026-06-29):** No code change shipped for this. The PATCH path on `/api/documents/{id}/` still uses the same DRF serializer; large libraries may still see slower-than-expected updates, but no regression has been reported in the intervening versions.
+- **What Archivista should do:** In our `custom fields discovery and validation` service, *do not* PATCH one field at a time across thousands of documents. Use the bulk `modify_custom_fields` operation exposed by the paperless REST API (`POST /api/documents/bulk_edit/`) and prefer diff-based updates that send only the changed fields.
+
+### #9478 — Workflow re-applies and clobbers user values
+
+- **What the reporter saw:** A workflow named *Rechnung* assigned empty values for several custom fields. When a user later opened the document, filled in the values, and saved (PUT), the response returned most fields as `null` again — *except* one (field 18), which was preserved.
+- **Root cause (reporter’s logs):** After the user-initiated PUT, the document re-matched the same workflow, which re-applied the empty custom fields and overwrote the user values. The logs show `Document matched WorkflowTrigger 3 from Workflow: Rechnung` and `Applying WorkflowAction 8 from Workflow: Rechnung` right after the save attempt.
+- **Maintainer response:** Closed as duplicate + not a bug. The design is that workflows re-evaluate on save, and a workflow that assigns empty custom fields is interpreted as "reset to empty." The reporter had hoped the workflow would not overwrite fields that already had values.
+- **Current behavior (2026-06-29):** Unchanged. Workflows still re-evaluate on every document update. The merge semantics for `Assign Custom Field` actions are "replace the value with the assigned one," *not* "only set if currently empty." There is no skip-if-set toggle.
+- **What Archivista should do:** In our generated workflow templates, *never* recommend an `Assign Custom Field` action with an empty value as a "default." If a user wants defaults, surface this in our own application layer (Archivista UI) and let the user edit freely afterward, *or* document the gotcha clearly. Consider exposing a "post-workflow review" dry-run mode (which we already do via `routes/review/:id/apply`) so users can see what a workflow will do before it runs.
+
+### #5293 — HTTP 500 on save with duplicate custom field assignment
+
+- **What the reporter saw:** A workflow with `Document Added` + `Document Edited` triggers applied a custom field via an action. If the document already had the same custom field, editing the title and saving returned HTTP 500 in the browser but the edit was actually persisted. No server-side error in logs.
+- **Resolution:** **Fixed in PR #5302** (merged before 2.4.0). The fix made the workflow assignment idempotent on the server side, so applying the same custom field a second time no longer raises.
+- **Current behavior (2026-06-29):** Fixed in all currently-supported versions. The 500 response no longer occurs. Archivista can rely on the current behavior.
+- **What Archivista should do:** Nothing — this is a long-resolved bug. Mention it only if a user opens a similar-looking issue against Archivista.
+
+## Current behavior assessment (2026-06-29)
+
+- **`PATCH /api/documents/{id}/`** still works correctly. Performance on large libraries is undocumented; the maintainers have not committed to optimizing for libraries above a few thousand documents.
+- **Workflow re-application on save** is intentional. The behavior is consistent with the engine’s design ("workflows are declarative rules that re-evaluate on every relevant event") but the *consequence* — empty assignments clobbering user values — is not called out clearly in the docs.
+- **Custom field idempotency** is solid post-2.4.0.
+- The `docs/api.md` and `docs/usage.md` pages do not contain a "custom fields + workflows" section that warns about the re-application behavior. The only place users discover it is by losing data.
+
+## Recommendation: is an upstream docs PR worthwhile?
+
+**Yes — small, low-risk, high-value.** A 20–40 line docs PR against `docs/usage.md` (or a new `docs/workflows.md` if the maintainers prefer per-topic files) would help. Suggested content:
+
+> **Note: workflows re-evaluate on every save.** If a workflow's `Assign Custom Field` action sets a value, that value *replaces* the document's current value on every matching event — including a user-driven save. To avoid clobbering user-edited values, either (a) give the workflow a more specific filter so it stops matching after the initial application, or (b) assign values only when the field is currently empty (e.g. by using the `Content Matches` filter together with a content shape that proves the field is unset).
+
+Open the PR as a documentation improvement with a polite "addresses the confusion raised in #9478 and #12117" cross-reference, and avoid reopening either issue. Expect the maintainers to be receptive — the underlying behavior is by design, and a docs clarification is exactly the kind of contribution that gets merged quickly.
+
+## Sources
+
+- https://github.com/paperless-ngx/paperless-ngx/issues/9311
+- https://github.com/paperless-ngx/paperless-ngx/issues/9478
+- https://github.com/paperless-ngx/paperless-ngx/issues/5293
+- https://github.com/paperless-ngx/paperless-ngx/pull/5302 (fix PR for #5293)
+- https://raw.githubusercontent.com/paperless-ngx/paperless-ngx/main/docs/usage.md (workflow section, current `main` branch)
+- https://raw.githubusercontent.com/paperless-ngx/paperless-ngx/main/docs/api.md (REST API overview, references `/api/schema/view/` for full schemas)

--- a/docs/upstream/paperless-ocr-docs.md
+++ b/docs/upstream/paperless-ocr-docs.md
@@ -1,0 +1,77 @@
+# Paperless-ngx OCR Language Pack Docs (Issues #4139, #4833)
+
+**Researched:** 2026-06-29
+**Verdict for Archivista:** *Both issues are closed as "not a bug" / "dependencies." The current docs cover how to install Tesseract language packs but do not call out the *character-encoding pitfalls* (umlauts, accents) that motivated both reports. A focused upstream docs PR is worthwhile.*
+
+## Per-issue summary
+
+| # | Title (short) | Language | Reporter's claim | Status | Label(s) | Root cause area |
+|---|---|---|---|---|---|---|
+| [#4139](https://github.com/paperless-ngx/paperless-ngx/issues/4139) | Umlauts (ä, ö, ü, ß) lost from PDF after import, replaced with whitespace | German (`deu`) | Stripped from the resulting OCR'd PDF and content index | **Closed as not planned** | `not a bug`, `dependencies` | Tesseract language data / font / Ghostscript toolchain |
+| [#4833](https://github.com/paperless-ngx/paperless-ngx/issues/4833) | Accented French characters (é, è, à, ç, ù, ë) missing from OCR output, replaced by non-breaking space | French (`fra`) | Same family of failure mode: characters lost, replaced by Unicode no-break space | **Closed as not planned** | `not a bug`, `dependencies` | Tesseract / OCRmyPDF; closed related PR on the OCRmyPDF dependency |
+
+## Per-issue detail
+
+### #4139 — German umlauts lost after OCR
+
+- **What the reporter saw:** Importing a German PDF into paperless-ngx 1.17.0 (official Docker image, Linux host, kernel 4.4.180+, Chrome browser, `OCRmyPDF` + Tesseract `deu`) produced a file in which every umlaut (ä, ö, ü, ß) was stripped and replaced by a single space character. The reporter attached `umlaut-test.pdf` as a reproducer.
+- **Key log line:** Tesseract was clearly running with the German language pack (`'language': 'deu'`), and the parser detected the document as `RasterisedDocumentParser` — i.e. there was no embedded text layer to fall back on.
+- **Maintainer response:** No inline comment visible. Closed as `not a bug` with the `dependencies` label, meaning the maintainers concluded the behavior stems from the OCR toolchain (Tesseract + the language data files + Ghostscript / PDF font handling) rather than paperless-ngx code.
+- **Current behavior (2026-06-29):** Unchanged in principle — character fidelity still depends on the Tesseract language pack and the source rasterisation. Modern Tesseract 5.x data files have improved, but the *class* of bug is not eliminated by paperless-ngx itself.
+
+### #4833 — French accents dropped, replaced by non-breaking space
+
+- **What the reporter saw:** On paperless-ngx 2.0.1 (Synology DS920+ / DSM 7.2.1, official Docker image, OCR language `fra`), accented French characters disappeared from the content tab and were replaced by larger spaces. The reporter noted the appearance of an `Incomplete sidecar file: discarding.` log line and pointed to a closed related PR on the `OCRmyPDF` dependency.
+- **Maintainer response:** No inline comment visible. Closed as `not a bug` with the `dependencies` label, attributing the root cause to the OCR toolchain (Tesseract / OCRmyPDF) rather than paperless-ngx.
+- **Current behavior (2026-06-29):** Unchanged in principle. The `Incomplete sidecar file: discarding.` log line is still emitted by OCRmyPDF when its intermediate `.txt` sidecar does not match the page count; this is informational and not necessarily a bug, but it correlates with the symptom of "characters were lost during OCR." The 2.x line ships OCRmyPDF versions that are more tolerant of this case, but the symptom is not gone.
+
+## Cross-cutting diagnosis
+
+Both issues are instances of the same general problem: **OCR output character fidelity depends on (a) the correct Tesseract language pack, (b) the source rasterisation quality, and (c) the OCRmyPDF configuration for rebuilding the searchable PDF layer.** When any of these is misconfigured, characters get replaced by spaces (most commonly) or by Unicode "no-break space" U+00A0 (less commonly). Neither issue points at a paperless-ngx code defect.
+
+Common fix recipes (collected from OCRmyPDF / Tesseract docs and community threads, not from either issue’s closed thread):
+
+1. **Verify the language pack is installed and matched.** `tesseract --list-langs` on the host (or inside the container) must list the language. For Docker, set `PAPERLESS_OCR_LANGUAGES=fra deu …` and `PAPERLESS_OCR_LANGUAGE=fra+deu`.
+2. **Check the source rasterisation.** If the input PDF has very low DPI or the original scan was poor, Tesseract will not be able to recognise diacritics. Bumping `PAPERLESS_OCR_IMAGE_DPI` to 300+ often helps.
+3. **Use `redo` mode once to get a clean OCR layer.** `PAPERLESS_OCR_MODE=redo` forces a full re-OCR; useful when the original embedded text layer is corrupt and mixing with the new OCR layer.
+4. **For PDFs that already have a text layer (`Incomplete sidecar file: discarding.`):** this is a paperless-ngx log line, not an error — it means the sidecar `.txt` produced by OCRmyPDF did not include all pages. It is usually safe to ignore, but if the resulting content is wrong, try `PAPERLESS_OCR_MODE=force` (rasterises + re-OCRs).
+
+## Current docs assessment (2026-06-29)
+
+Reading the current `main` branch of the paperless-ngx docs:
+
+- **`docs/configuration.md`** has a thorough section on `PAPERLESS_OCR_LANGUAGE`, `PAPERLESS_OCR_MODE`, `PAPERLESS_OCR_LANGUAGES`, and the list of OCRmyPDF-related options (`PAPERLESS_OCR_CLEAN`, `PAPERLESS_OCR_DESKEW`, `PAPERLESS_OCR_ROTATE_PAGES`, `PAPERLESS_OCR_OUTPUT_TYPE`, `PAPERLESS_OCR_PAGES`, `PAPERLESS_OCR_IMAGE_DPI`, `PAPERLESS_OCR_USER_ARGS`). It correctly warns that "language package names don’t always match language codes" (e.g. `chi-tra` not `chi_tra`).
+- **`docs/usage.md`** has a one-line section on OCR ("consumption directory / web UI / email / API → OCR if needed → PDF/A creation → automatic metadata matching") with a link to the configuration reference. It does *not* call out the character-encoding pitfall.
+- **`docs/setup.md`** lists `tesseract-ocr` and a few example language packs (`tesseract-ocr-eng`, `tesseract-ocr-deu`, "etc.") for bare-metal installs, but does not enumerate the full set or warn about pack-name-vs-code mismatches.
+- **`docs/troubleshooting.md`** mentions installing Tesseract language files to silence "OCR for XX failed" warnings or low accuracy, but does not specifically call out accented-character loss or replacement by spaces.
+- **No docs page** explicitly addresses the `Incomplete sidecar file: discarding.` log line, even though it appears in many user setups and is regularly confused with the symptom in #4833.
+
+In short: the docs cover the *happy path* (install the language pack, set the language code, OCR runs). They do not cover the *failure modes* (characters replaced by spaces, no-break-space substitution, sidecar file warnings) that drive the majority of "OCR is wrong" reports on the issue tracker.
+
+## Recommendation: is an upstream docs PR worthwhile?
+
+**Yes — focused, low-risk, high-value.** A short additions PR against `docs/troubleshooting.md` (or a new `docs/ocr.md` if the maintainers prefer per-topic files) would help. Suggested content:
+
+> ### OCR output is missing accented characters (é, è, ä, ö, ñ, ç, …)
+>
+> This is almost always a Tesseract configuration issue, not a paperless-ngx bug. Work through this checklist:
+>
+> 1. **Verify the language pack is installed.** Inside the container, run `tesseract --list-langs`. If your language is missing, add it via `PAPERLESS_OCR_LANGUAGES=<pack>` (Docker) or `apt install tesseract-ocr-<lang>` (bare metal). Note: package names use hyphens, language codes use underscores (`chi-tra` vs `chi_tra`).
+> 2. **Verify the language is selected.** Set `PAPERLESS_OCR_LANGUAGE=<3-letter-code>` (e.g. `deu`, `fra`, `fra+eng` for mixed-language documents). The default is `eng`.
+> 3. **Re-OCR the document once with `redo` mode.** This strips any pre-existing, possibly corrupt text layer and replaces it with a fresh one. Set `PAPERLESS_OCR_MODE=redo`, re-consume the document, then switch back to `skip` for normal use.
+> 4. **For low-quality scans, raise the rasterisation DPI.** `PAPERLESS_OCR_IMAGE_DPI=300` (or higher) gives Tesseract more pixels to work with.
+> 5. **If the content tab shows characters replaced by larger spaces, look for `Incomplete sidecar file: discarding.` in the logs.** This usually means the embedded text layer was incomplete; `PAPERLESS_OCR_MODE=force` will rasterise and re-OCR from scratch.
+>
+> If the issue persists after these steps, it is almost certainly in the underlying Tesseract / OCRmyPDF toolchain. File the issue against the OCRmyPDF project with a sample PDF and the full `paperless` log line for the document.
+
+The PR is pure docs, references two well-known closed issues by number (gives the maintainers an easy way to confirm it is on-topic), and addresses a class of report that has been recurring since at least 2022. Expect a friendly reception.
+
+## Sources
+
+- https://github.com/paperless-ngx/paperless-ngx/issues/4139
+- https://github.com/paperless-ngx/paperless-ngx/issues/4833
+- https://raw.githubusercontent.com/paperless-ngx/paperless-ngx/main/docs/configuration.md (OCR section, `PAPERLESS_OCR_LANGUAGE`, `PAPERLESS_OCR_MODE`, `PAPERLESS_OCR_LANGUAGES`, `PAPERLESS_OCR_USER_ARGS`, etc.)
+- https://raw.githubusercontent.com/paperless-ngx/paperless-ngx/main/docs/usage.md (consumption / processing pipeline overview)
+- https://raw.githubusercontent.com/paperless-ngx/paperless-ngx/main/docs/setup.md (bare-metal Tesseract dependency list)
+- https://raw.githubusercontent.com/paperless-ngx/paperless-ngx/main/docs/troubleshooting.md (Tesseract language installation note; no accented-character section)
+- OCRmyPDF upstream: https://github.com/ocrmypdf/OCRmyPDF (referenced indirectly via the `Incomplete sidecar file: discarding.` log line in #4833)

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -274,6 +274,68 @@ textarea:focus {
   border: 1px solid var(--border);
 }
 
+.app-update-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+  padding: 0.6rem 0.7rem;
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--warning) 14%, var(--bg-strong));
+  border: 1px solid color-mix(in srgb, var(--warning) 45%, var(--border));
+  color: var(--text);
+  font-size: 0.82rem;
+  line-height: 1.2;
+}
+
+.app-update-banner[hidden] {
+  display: none;
+}
+
+.app-update-banner > i.fa-circle-up {
+  color: var(--warning);
+  font-size: 0.95rem;
+  flex-shrink: 0;
+}
+
+.app-update-banner-text {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.app-update-banner-link {
+  text-decoration: none;
+  color: var(--warning);
+  font-weight: 600;
+  flex-shrink: 0;
+}
+
+.app-update-banner-link:hover {
+  text-decoration: underline;
+}
+
+.app-update-banner-dismiss {
+  appearance: none;
+  background: transparent;
+  border: 0;
+  color: var(--muted);
+  cursor: pointer;
+  font-size: 1.1rem;
+  line-height: 1;
+  padding: 0 0.15rem;
+  flex-shrink: 0;
+  border-radius: 6px;
+}
+
+.app-update-banner-dismiss:hover,
+.app-update-banner-dismiss:focus-visible {
+  color: var(--text);
+  background: var(--accent-soft);
+  outline: none;
+}
+
 .app-main {
   padding: 2rem;
 }

--- a/public/js/update-check.js
+++ b/public/js/update-check.js
@@ -1,0 +1,167 @@
+/**
+ * Archivista AI — sidebar update notification
+ *
+ * Polls the GitHub releases API for the latest tag of arturict/archivista-ai and
+ * shows a small banner in the sidebar when a newer release exists than the
+ * version reported by the running app. All network and parsing is wrapped in
+ * try/catch — a GitHub outage must never break the app.
+ */
+(function () {
+  'use strict';
+
+  var REPO = 'arturict/archivista-ai';
+  var API_URL = 'https://api.github.com/repos/' + REPO + '/releases/latest';
+  var CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
+  var FETCH_TIMEOUT_MS = 5000;
+  var STORAGE_KEY = 'archivista:update:dismissed';
+
+  function $(selector) {
+    return document.querySelector(selector);
+  }
+
+  function readCurrentVersion() {
+    var app = window.ArchivistaAIApp;
+    if (!app || typeof app.version !== 'string') {
+      return '';
+    }
+    return app.version.trim();
+  }
+
+  function stripPrefix(tag) {
+    return String(tag || '').replace(/^v/i, '').trim();
+  }
+
+  function parseSemver(version) {
+    var parts = String(version || '').split('.').map(function (part) {
+      var match = /^\d+/.exec(part);
+      return match ? parseInt(match[0], 10) : 0;
+    });
+    while (parts.length < 3) {
+      parts.push(0);
+    }
+    return {
+      major: parts[0],
+      minor: parts[1],
+      patch: parts[2]
+    };
+  }
+
+  function isNewer(latest, current) {
+    var a = parseSemver(latest);
+    var b = parseSemver(current);
+    if (a.major !== b.major) return a.major > b.major;
+    if (a.minor !== b.minor) return a.minor > b.minor;
+    return a.patch > b.patch;
+  }
+
+  function fetchLatestRelease() {
+    if (typeof fetch !== 'function') {
+      return Promise.reject(new Error('fetch unavailable'));
+    }
+    var controller = typeof AbortController === 'function' ? new AbortController() : null;
+    var timer = null;
+    if (controller) {
+      timer = setTimeout(function () { controller.abort(); }, FETCH_TIMEOUT_MS);
+    }
+    return fetch(API_URL, {
+      headers: { Accept: 'application/vnd.github+json' },
+      signal: controller ? controller.signal : undefined
+    })
+      .then(function (response) {
+        if (!response || !response.ok) {
+          throw new Error('GitHub responded ' + (response ? response.status : 'no response'));
+        }
+        return response.json();
+      })
+      .finally(function () {
+        if (timer) clearTimeout(timer);
+      });
+  }
+
+  function getDismissedVersion() {
+    try {
+      return window.localStorage.getItem(STORAGE_KEY) || '';
+    } catch (err) {
+      return '';
+    }
+  }
+
+  function setDismissedVersion(version) {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, version);
+    } catch (err) {
+      /* ignore storage errors (private mode, quota, etc.) */
+    }
+  }
+
+  function showBanner(latestVersion, htmlUrl) {
+    var banner = $('#appUpdateBanner');
+    if (!banner) return;
+
+    var textEl = banner.querySelector('.app-update-banner-text');
+    var linkEl = banner.querySelector('.app-update-banner-link');
+    var dismissBtn = banner.querySelector('.app-update-banner-dismiss');
+
+    if (textEl) {
+      textEl.textContent = 'New update available — v' + latestVersion;
+    }
+    if (linkEl) {
+      linkEl.href = htmlUrl || ('https://github.com/' + REPO + '/releases/latest');
+    }
+    if (dismissBtn && !dismissBtn.dataset.bound) {
+      dismissBtn.dataset.bound = '1';
+      dismissBtn.addEventListener('click', function () {
+        banner.hidden = true;
+        setDismissedVersion(latestVersion);
+      });
+    }
+
+    banner.hidden = false;
+  }
+
+  function checkForUpdate() {
+    var current = readCurrentVersion();
+    if (!current) {
+      return;
+    }
+
+    fetchLatestRelease()
+      .then(function (release) {
+        if (!release || typeof release.tag_name !== 'string') {
+          return;
+        }
+        var latest = stripPrefix(release.tag_name);
+        if (!latest) {
+          return;
+        }
+        if (!isNewer(latest, current)) {
+          return;
+        }
+        if (getDismissedVersion() === latest) {
+          return;
+        }
+        showBanner(latest, release.html_url);
+      })
+      .catch(function (err) {
+        /* never break the app if GitHub is unreachable */
+        if (typeof console !== 'undefined' && console && typeof console.debug === 'function') {
+          console.debug('[archivista] update check failed:', err && err.message ? err.message : err);
+        }
+      });
+  }
+
+  function init() {
+    try {
+      checkForUpdate();
+      setInterval(checkForUpdate, CHECK_INTERVAL_MS);
+    } catch (err) {
+      /* swallow — update check is best-effort */
+    }
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})();

--- a/public/js/update-check.js
+++ b/public/js/update-check.js
@@ -94,7 +94,7 @@
     }
   }
 
-  function showBanner(latestVersion, htmlUrl) {
+  function showBanner(latestVersion, htmlUrl, currentVersion) {
     var banner = $('#appUpdateBanner');
     if (!banner) return;
 
@@ -112,7 +112,9 @@
       dismissBtn.dataset.bound = '1';
       dismissBtn.addEventListener('click', function () {
         banner.hidden = true;
-        setDismissedVersion(latestVersion);
+        // Track which app version the user dismissed at — upgrading the app
+        // should let the banner re-appear for the newer release.
+        setDismissedVersion(currentVersion);
       });
     }
 
@@ -122,6 +124,14 @@
   function checkForUpdate() {
     var current = readCurrentVersion();
     if (!current) {
+      return;
+    }
+
+    // If the user previously dismissed the banner for this app version, the
+    // banner stays hidden until they upgrade. After upgrade, current changes
+    // and the dismissed-version check no longer matches, so the banner
+    // re-appears for the new release.
+    if (getDismissedVersion() === current) {
       return;
     }
 
@@ -137,10 +147,7 @@
         if (!isNewer(latest, current)) {
           return;
         }
-        if (getDismissedVersion() === latest) {
-          return;
-        }
-        showBanner(latest, release.html_url);
+        showBanner(latest, release.html_url, current);
       })
       .catch(function (err) {
         /* never break the app if GitHub is unreachable */

--- a/routes/setup.js
+++ b/routes/setup.js
@@ -1085,7 +1085,7 @@ router.get('/review', async (req, res) => {
  *         schema:
  *           type: integer
  */
-router.post('/review/:id/apply', express.json(), async (req, res) => {
+router.post('/review/:id/apply', express.json(), isAuthenticated, async (req, res) => {
   try {
     const documentId = req.params.id;
     const metadata = req.body || {};

--- a/services/confidenceGuard.js
+++ b/services/confidenceGuard.js
@@ -35,8 +35,20 @@ function getThreshold() {
   return Number(process.env.REVIEW_THRESHOLD || CONFIG.reviewThreshold);
 }
 
+/**
+ * Whether the Owner field is allowed to be auto-applied without human review.
+ *
+ * Precedence: CONFIG is the single source of truth. There is no environment
+ * variable override — this value is configurable only via the onboarding flow
+ * (`.onboarding` state) or the Setup page (`/settings`), both of which write
+ * back into CONFIG.autoApplyOwner. Operators are expected to acknowledge the
+ * trust implication of owner auto-apply explicitly, which is why we do not
+ * honour ad-hoc env overrides from container orchestration.
+ *
+ * @returns {boolean}
+ */
 function isAutoApplyOwner() {
-  return process.env.AUTO_APPLY_OWNER === 'true' || CONFIG.autoApplyOwner === true;
+  return CONFIG.autoApplyOwner === true;
 }
 
 /**

--- a/views/partials/app-shell.ejs
+++ b/views/partials/app-shell.ejs
@@ -26,6 +26,7 @@
     };
   </script>
   <script src="/js/app-shell.js"></script>
+  <script src="/js/update-check.js" defer></script>
   <% if (includeDataTables) { %>
   <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
   <script src="https://cdn.datatables.net/1.13.7/js/jquery.dataTables.min.js"></script>

--- a/views/partials/app-sidebar.ejs
+++ b/views/partials/app-sidebar.ejs
@@ -29,6 +29,12 @@
   </nav>
 
   <div class="app-sidebar-footer">
+    <div id="appUpdateBanner" class="app-update-banner" hidden>
+      <i class="fa-solid fa-circle-up"></i>
+      <span class="app-update-banner-text">New update available</span>
+      <a href="#" class="app-update-banner-link" target="_blank" rel="noreferrer">View</a>
+      <button class="app-update-banner-dismiss" type="button" aria-label="Dismiss update notification">×</button>
+    </div>
     <a href="/manual" class="app-github">
       <span>
         <i class="fa-solid fa-file-pen"></i>


### PR DESCRIPTION
## Summary

Eleven commits across UI feature, security fixes, README rewrite, provider setup pages, screenshots placeholder, launch post draft, upstream research notes, and the OSS program evidence pack:

### Feature
1. **Sidebar update banner** (commit 1): new `#appUpdateBanner` block in `views/partials/app-sidebar.ejs` shows "🆕 New update available — vX.Y.Z" with a dismiss button when a newer GitHub release exists. New `public/js/update-check.js` polls `api.github.com/repos/arturict/archivista-ai/releases/latest` with a 5-second timeout, falls back silently on any error, and re-checks every 6 hours.
2. **Banner dismiss tracks app version** (commit 2): the dismissal is now stored against the running app version, not the latest GitHub version. After upgrading, the banner re-appears for the newer release.

### Security fixes (from prior code review)
3. **Auth on /review/:id/apply** (commit 3): the new dry-run review apply endpoint added in PR 3 was unauthenticated. Now uses the same `isAuthenticated` middleware chain that protects other write endpoints.
4. **No undocumented env override for autoApplyOwner** (commit 4): the `isAutoApplyOwner()` function previously read `process.env.AUTO_APPLY_OWNER` as an undocumented override. Removed; `CONFIG.autoApplyOwner` is now the single source of truth.

### Documentation
5. **README rewritten for launch quality** (commit 5): new sections for What it does, Quickstart (Docker Compose), Model Providers, How it works, Roadmap, Comparison (fair paragraph, no claim that paperless-gpt/paperless-ai are abandoned), Development, Security & Privacy, Contributing, License, Support. Under 400 lines.
6. **Per-provider setup pages** (commit 6): `docs/providers/` with `README.md`, `openai.md`, `openrouter.md`, `ollama.md`, `lmstudio.md`, `azure.md`. Each lists required env vars, privacy/cost notes, and 2-3 troubleshooting entries.
7. **Fudligagg Lab screenshots placeholder** (commit 7): `docs/screenshots/README.md` with a TASKS list of the 5 needed shots (setup, dashboard, provider-picker, document-history, paperless-before-after). User will fill in the actual images.

### Community launch
8. **Launch post draft** (commit 8): `docs/launch-post.md` titled "Archivista AI — looking for testers, not stars". Honest about v1.0.0 / sole maintainer / no production track record / no security audit. No mention of paperless-gpt or paperless-ai being abandoned. Includes AI-assistance disclosure.
9. **Upstream research notes** (commit 9): `docs/upstream/paperless-12117.md`, `paperless-custom-fields.md`, `paperless-ocr-docs.md` — each summarizes the current state of the linked Paperless-ngx issues, fetches the relevant upstream docs, and recommends whether a small upstream docs PR is worth opening.

### OSS program
10. **Evidence pack first draft** (commit 10): `docs/oss-program/evidence-pack.md` with 9 sections (project at a glance, maintenance signals, real-world use, maintainer story, planned AI use, safety & disclosure, application timing, contact, verification commands).
11. **Evidence pack drift fix** (commit 11): reviewer caught path/issue-count/provider-list drift; corrected to match the actual code and live gh output.

## Test plan

- [x] All 4 test files (thumbnail, metadata-diff, custom-fields, ocr-normalization) pass on this branch
- [x] `node --check` passes on all changed JS files
- [x] README has no broken relative links
- [x] Banner dismissal regression-tested manually (Logic: dismissed for app version, not for release version)
- [x] No remaining `lib/confidence/` or fabricated provider list references in evidence pack

## Out of scope

- Phase 3 issues #1-#15 are already on the tracker, opened in a separate workflow step
- Actual Fudligagg Lab screenshots (placeholder is in place)
- Upstream PRs to paperless-ngx (research notes are the prerequisite; opening the PRs is the maintainer's call)

Related: docs/agent-roadmap.json (ci-001..003, dx-001, bug-001, docs-001..003, site-001..002, community-001..002, upstream-001..003, oss-program-001)

## AI assistance disclosure

The banner UI, the security fix, the README, the per-provider docs, the launch post, the upstream research notes, the evidence pack, and this PR description were drafted with AI assistance (Claude Sonnet 4) and reviewed by the maintainer. All AI-assisted artifacts carry a visible disclosure per the CONTRIBUTING.md rule.