### PR TITLE
Release v2.0.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ## Unreleased
 
+## 2.0.0-alpha.1 - 2026-07-12
+
+- Added an optional review-first workflow with durable suggestions, structured
+  metadata diffs, Apply/Reject actions, original-metadata snapshots, restore,
+  retries, and reconciliation.
+- Added subscription-backed ChatGPT/Codex and GitHub Copilot providers using
+  official runtimes, device authentication, account-visible model discovery,
+  and disabled agent tools.
+- Added Ollama Cloud, OpenCode Go, Anthropic, OpenRouter, Azure OpenAI, local
+  Ollama, OpenAI direct, and OpenAI-compatible provider paths with isolated
+  credentials and provider-aware health checks.
+- Added controlled tag groups, an exception queue, tag caps, custom fields,
+  optional owner assignment, OCR rescue, terminal-failure handling, and
+  interrupted-job recovery.
+- Added hardened thumbnail handling, same-origin mutation checks, MFA, rate
+  limits, SSRF-safe external enrichment, generated JWT secrets, and strict
+  TypeScript checks across the application.
+- Added versioned v2 installation, upgrade, removal, provider, privacy,
+  troubleshooting, and feature documentation with sanitized screenshots.
+- Added optional, off-by-default aggregate installation analytics with rotating
+  daily/monthly identifiers, exact local payload preview, and a reference
+  receiver with bounded retention. No collector is contacted unless an HTTPS
+  endpoint is explicitly configured.
+- Added GitHub traffic archival, repository discovery metadata, launch assets,
+  an Unraid template, and a contextual GitHub star prompt.
+- **Upgrade note:** Back up `tagvico_ai_data`, migrate deprecated
+  `ARCHIVISTA_*` variables to `TAGVICO_*`, pin the exact prerelease image, and
+  validate representative documents in Review first before enabling Automatic.
+
 - Migrated the dashboard charts from Chart.js to Apache ECharts 5 for smoother animations, sharper tooltips, and better theme integration (doughnut, bar, rose/pie, and area-line visualizations).
 - Refined the dashboard visual design: subtle card hover elevation, tabular-numeral KPIs, consistent chart legends, and polished empty states — preserving the existing neo-brutalist aesthetic.
 - Added a clearly-labelled **cost estimate** to the dashboard: total estimated spend, average cost per document, and an input-vs-output cost split, derived from tracked token totals and the active model's public list price (`services/modelPricing.ts`). Free local models (Ollama) and installations without tracked usage correctly show no cost, and unknown cloud models fall back to a conservative estimate flagged with an asterisk.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ with local or hosted models.** Turn OCR text into clean titles, tags,
 correspondents, document types, dates, languages, custom fields, and optional
 owner assignments while keeping control of the model and privacy boundary.
 
-[![Status: Alpha](https://img.shields.io/badge/status-alpha-ff6f00.svg)](#-alpha--under-active-development)
+[![Status: Alpha](https://img.shields.io/badge/status-alpha-ff6f00.svg)](docs/STATUS.md)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/arturict/tagvico-ai)](https://github.com/arturict/tagvico-ai/releases)
 [![CI](https://img.shields.io/github/actions/workflow/status/arturict/tagvico-ai/ci.yml?branch=main&label=CI)](https://github.com/arturict/tagvico-ai/actions/workflows/ci.yml)
@@ -58,7 +58,7 @@ services:
   tagvico-ai:
     # Pin an immutable release tag for upgrades you can rely on.
     # See https://github.com/arturict/tagvico-ai/releases for the current version.
-    image: ghcr.io/arturict/tagvico-ai:1.3.0
+    image: ghcr.io/arturict/tagvico-ai:2.0.0-alpha.1
     container_name: tagvico-ai
     restart: unless-stopped
     cap_drop:
@@ -106,7 +106,7 @@ docker run -d \
   -p 8080:3000 \
   -e TAGVICO_AI_PORT=3000 \
   -v tagvico_ai_data:/app/data \
-  ghcr.io/arturict/tagvico-ai:1.3.0
+  ghcr.io/arturict/tagvico-ai:2.0.0-alpha.1
 ```
 
 </details>
@@ -172,7 +172,7 @@ History supports explicit rescan and restoration of the first metadata snapshot 
 ## Upgrades
 
 1. Check the latest release at <https://github.com/arturict/tagvico-ai/releases>.
-2. Update the image tag in `docker-compose.yml` to the new **immutable version tag** shown on the releases page—for example `ghcr.io/arturict/tagvico-ai:1.3.0`. Avoid `:latest` in production: it makes rollback ambiguous and can pull a breaking change unexpectedly.
+2. Update the image tag in `docker-compose.yml` to the new **immutable version tag** shown on the releases page—for example `ghcr.io/arturict/tagvico-ai:2.0.0-alpha.1`. Avoid `:latest` in production: it makes rollback ambiguous and can pull a breaking change unexpectedly.
 3. `docker compose pull && docker compose up -d`.
 
 Tagvico is stateless across restarts: configuration, processing history, and the local admin account live in the `tagvico_ai_data` volume, so upgrades do not touch your settings.
@@ -219,7 +219,7 @@ The development server listens on `http://localhost:3000`. The application sourc
 
 Bug reports, feature requests, and pull requests are welcome. The issue chooser asks only for the information needed to reproduce or evaluate a change, and the pull-request template includes a short verification checklist. See [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow. For security disclosures, follow [SECURITY.md](SECURITY.md) instead of opening a public issue.
 
-See [docs/STATUS.md](docs/STATUS.md) for the current development status, what may still change before 1.0, and recommendations for running alpha software in production.
+See [docs/STATUS.md](docs/STATUS.md) for the current development status, what may still change before stable v2, and recommendations for running the v2 prerelease.
 
 ## License
 

--- a/deploy/unraid/tagvico-ai.xml
+++ b/deploy/unraid/tagvico-ai.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <Container version="2">
   <Name>Tagvico AI</Name>
-  <Repository>ghcr.io/arturict/tagvico-ai:1.3.0</Repository>
+  <Repository>ghcr.io/arturict/tagvico-ai:2.0.0-alpha.1</Repository>
   <Registry>https://github.com/arturict/tagvico-ai/pkgs/container/tagvico-ai</Registry>
   <Network>bridge</Network>
   <WebUI>http://[IP]:[PORT:3000]/setup</WebUI>

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,10 +1,12 @@
 # Project status
 
-**Status:** Alpha — under active development.
+**Status:** v2 prerelease (`2.0.0-alpha.1`) — under active testing.
 
 ## What this means
 
-Tagvico AI is in **alpha**. We are stabilizing the core filing workflow and provider adapters. The TypeScript migration is complete. You can run it for real, and many people do, but the following may change at any time without a deprecation cycle:
+Tagvico AI v2 is in **prerelease testing**. The TypeScript migration and core
+review-first filing workflow are complete, but the following may still change
+before stable `2.0.0`:
 
 - The HTTP/REST API surface (paths, request bodies, response fields).
 - The configuration schema in `data/.env` and the setup wizard.
@@ -13,7 +15,7 @@ Tagvico AI is in **alpha**. We are stabilizing the core filing workflow and prov
 - Default values, output formats, and confidence thresholds.
 - File paths, filenames, and the on-disk layout inside the persistent volume.
 
-## Recommendations for alpha users
+## Recommendations for prerelease users
 
 - **Pin a specific release tag** in `docker-compose.yml` (for example `ghcr.io/arturict/tagvico-ai:<version>`), never `:latest`. We publish immutable tags per release.
 - **Back up the `tagvico_ai_data` volume** before upgrading. The volume holds your admin account, provider settings, and processing history.
@@ -28,9 +30,9 @@ Tagvico AI is in **alpha**. We are stabilizing the core filing workflow and prov
 - The local admin account: the SQLite-stored credentials in the persistent volume.
 - The OpenAI-compatible provider contract: anything that speaks the OpenAI Chat Completions API works the same way.
 
-## Reporting alpha issues
+## Reporting prerelease issues
 
-Alpha is exactly the phase where feedback is most useful. Please file issues for:
+The prerelease window is where feedback is most useful. Please file issues for:
 
 - Surprising behavior or errors during setup.
 - Provider failures, malformed responses, or token-limit issues.
@@ -39,10 +41,11 @@ Alpha is exactly the phase where feedback is most useful. Please file issues for
 
 Security issues must **not** be filed as public issues — see [SECURITY.md](../SECURITY.md).
 
-## Roadmap toward 1.0
+## Roadmap toward stable v2
 
 - [x] Complete the TypeScript migration of all services and routes.
 - Lock the REST API surface, configuration schema, and database schema.
-- Cut a release candidate, run a community testing window, then tag 1.0.
+- Complete representative Paperless ingest, restore, OCR, and provider-account
+  checks, then tag stable `2.0.0`.
 
 This document lives at `docs/STATUS.md` and is updated when the project status changes.

--- a/docs/releases/v2.0.0-alpha.1.md
+++ b/docs/releases/v2.0.0-alpha.1.md
@@ -1,0 +1,46 @@
+# Tagvico AI v2.0.0-alpha.1
+
+This is the first public v2 prerelease. It is intended for representative
+testing with an existing Paperless-ngx installation before stable `2.0.0`.
+
+## Highlights
+
+- Review suggestions before writing them, or opt into Automatic mode per
+  installation.
+- Inspect structured metadata diffs, apply or reject durable suggestions, and
+  restore the first captured metadata snapshot.
+- Keep tag vocabulary controlled with groups, caps, and an exception queue.
+- Use local Ollama, direct APIs, compatible gateways, OpenCode Go, Ollama
+  Cloud, GitHub Copilot, or experimental ChatGPT subscription access.
+- Recover OCR-poor documents, interrupted work, retries, and terminal failures
+  from the Operations UI.
+- See token use, estimated model cost, history, runner state, and provider
+  health from the web interface.
+- Optionally share coarse installation analytics. Sharing is off by default,
+  uses rotating identifiers, exposes the exact payload locally, and requires an
+  explicitly configured HTTPS receiver.
+
+## Upgrade from v1
+
+1. Stop Tagvico and back up the complete `tagvico_ai_data` volume.
+2. Replace deprecated pre-Tagvico environment variables with their documented
+   `TAGVICO_*` equivalents.
+3. Pin `ghcr.io/arturict/tagvico-ai:2.0.0-alpha.1`; do not use `latest` for this
+   prerelease.
+4. Start the container, inspect its logs, and verify `/health` and
+   `/api/health`.
+5. Process synthetic or non-sensitive representative documents in **Review
+   first** before enabling Automatic writes.
+
+Do not run v1 and v2 against the same data volume simultaneously. Restore the
+volume backup before rolling back if v2 has migrated its database.
+
+## Known prerelease boundaries
+
+- ChatGPT subscription access is experimental and is not an API SLA.
+- Model catalogs, entitlements, pricing, and quotas remain provider-controlled.
+- The REST/configuration/database contracts may still change before stable v2.
+- The reference analytics receiver must be deployed separately; no official
+  collector endpoint is embedded in this prerelease.
+
+Full documentation: https://tagvico.arturf.ch/docs/


### PR DESCRIPTION
## Release

Prepares the first public v2 prerelease: `v2.0.0-alpha.1`.

## Changes

- cuts the v2 prerelease changelog
- points README and Unraid examples at the immutable v2 prerelease image
- updates project status and stable-v2 roadmap language
- adds complete release notes with upgrade, rollback, privacy, and known-boundary guidance

## Why prerelease

The repository release gates still require representative real Paperless ingest and provider-account coverage before claiming stable `2.0.0`. This release intentionally preserves the alpha version already declared by the package and v2 documentation.

## Validation

- full quality suite
- 67/67 unit tests on Node 22
- versioned docs build
- final screenshot pixel inspection for private data
- Docker build from current sources
- runtime container `/health` smoke test
- production dependencies report 0 known vulnerabilities after `npm prune --omit=dev`

## After merge

Publish GitHub prerelease `v2.0.0-alpha.1` from `main`; the release workflow will build and publish amd64/arm64 GHCR images.