### PR TITLE
Keep latest container tag on stable releases

### DIFF
--- a/.github/workflows/docker-build-push.yml
+++ b/.github/workflows/docker-build-push.yml
@@ -39,7 +39,10 @@ jobs:
           tags: |
             type=schedule,pattern=nightly
             type=semver,pattern={{version}},enable=${{ github.event_name == 'release' }}
-            type=raw,value=latest,enable=${{ github.event_name == 'release' }}
+            # Prereleases get only their immutable semver tag. Keep :latest on
+            # the newest stable release so unattended deployments never jump
+            # to an alpha, beta, or release candidate.
+            type=raw,value=latest,enable=${{ github.event_name == 'release' && !github.event.release.prerelease }}
 
       - name: Build and push
         uses: docker/build-push-action@v5


### PR DESCRIPTION
## Fix

Prevents prerelease publication events from overwriting the mutable `latest` container tag.

Prereleases continue to receive their exact immutable semver tag. `latest` is emitted only for non-prerelease GitHub releases.

## Why

Publishing `v2.0.0-alpha.1` exposed that the previous condition checked only the event type, so `latest` briefly pointed at the alpha image. After this PR, `latest` will remain on the newest stable release.

## Verification

The immutable v2 alpha manifest remains available for amd64 and arm64. Registry `latest` will be restored separately to the stable v1.3.0 manifest.