### PR TITLE
Fix final v2 release regressions

### DIFF
--- a/routes/setup.ts
+++ b/routes/setup.ts
@@ -4609,8 +4609,11 @@ router.post('/api/history/:id/restore', async (req: Req, res: Res) => {
     owner: snapshot.owner ?? original.owner
   };
   Object.keys(update).forEach((key) => update[key] === undefined && delete update[key]);
-  const restored = await paperlessService.updateDocument(documentId, update);
-  if (!restored) return res.status(502).json({ error: 'Paperless-ngx rejected the restore' });
+  // Restoration must replace metadata exactly. The normal update path merges
+  // tags and preserves an existing correspondent, which is correct for new AI
+  // suggestions but would leave Tagvico-created values behind during restore.
+  const restored = await paperlessService.patchDocument(documentId, update);
+  if (!restored?.ok) return res.status(502).json({ error: restored?.error || 'Paperless-ngx rejected the restore' });
   await documentModel.addToHistory(documentId, update.tags || [], update.title, String(update.correspondent || ''));
   res.json({ success: true });
 });

--- a/server.ts
+++ b/server.ts
@@ -711,6 +711,7 @@ async function startScanning() {
     if (!isConfigured) {
       const port = resolveEnv('TAGVICO_AI_PORT', 'ARCHIVISTA_AI_PORT') || 3000;
       console.log(`Setup not completed. Visit http://your-machine-ip:${port}/setup to complete setup.`);
+      return;
     }
 
     const userId = await paperlessService.getOwnUserID();

--- a/tests/review-queue.test.js
+++ b/tests/review-queue.test.js
@@ -330,6 +330,77 @@ test('review page renders proposed metadata and durable suggestion ids', async (
   assert.doesNotMatch(html, /data-suggestion-id="1234"/);
 });
 
+test('history restore replaces metadata exactly, including empty tags', () => {
+  const script = `
+    const assert = require('node:assert/strict');
+    const path = require('node:path');
+    const root = ${JSON.stringify(repoRoot)};
+    const setupPath = path.join(root, 'dist/services/setupService.js');
+    const paperlessPath = path.join(root, 'dist/services/paperlessService.js');
+    let patchCall = null;
+
+    require.cache[setupPath] = {
+      id: setupPath,
+      filename: setupPath,
+      loaded: true,
+      exports: { isConfigured: async () => true }
+    };
+    require.cache[paperlessPath] = {
+      id: paperlessPath,
+      filename: paperlessPath,
+      loaded: true,
+      exports: {
+        patchDocument: async (id, patch) => {
+          patchCall = { id, patch };
+          return { ok: true, after: { id, ...patch }, diff: [] };
+        },
+        updateDocument: async () => { throw new Error('restore must not use the merging update path'); }
+      }
+    };
+
+    const model = require(path.join(root, 'dist/models/document.js'));
+    const express = require(path.join(root, 'node_modules/express'));
+    const cookieParser = require(path.join(root, 'node_modules/cookie-parser'));
+
+    (async () => {
+      await model.saveOriginalSnapshot(901, {
+        title: 'Original title',
+        tags: [],
+        correspondent: null,
+        document_type: null,
+        created: '2026-07-10',
+        language: 'en',
+        custom_fields: [],
+        owner: 7
+      });
+      const router = require(path.join(root, 'dist/routes/setup.js'));
+      const app = express();
+      app.use(cookieParser());
+      app.use(router);
+      const server = await new Promise((resolve) => {
+        const instance = app.listen(0, '127.0.0.1', () => resolve(instance));
+      });
+      const response = await fetch('http://127.0.0.1:' + server.address().port + '/api/history/901/restore', {
+        method: 'POST',
+        headers: { 'x-api-key': 'review-route-key' }
+      });
+      assert.equal(response.status, 200, await response.text());
+      assert.equal(patchCall.id, 901);
+      assert.deepEqual(patchCall.patch.tags, []);
+      assert.equal(patchCall.patch.correspondent, null);
+      assert.equal(patchCall.patch.document_type, null);
+      assert.equal(patchCall.patch.title, 'Original title');
+      await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+      await model.closeDatabase();
+    })().catch((error) => {
+      console.error(error);
+      process.exit(1);
+    });
+  `;
+
+  runIsolated(script);
+});
+
 test('settings UI exposes exclusive review-first and automatic write modes', () => {
   const template = fs.readFileSync(path.join(repoRoot, 'views', 'partials', 'config-form.ejs'), 'utf8');
   const browserCode = fs.readFileSync(path.join(repoRoot, 'public', 'js', 'config-form.js'), 'utf8');

--- a/website/versions/v2/installation.md
+++ b/website/versions/v2/installation.md
@@ -57,12 +57,18 @@ contains no credentials, private hostnames, document data, or account details.
 4. Select **Review first** for approval-based filing or **Automatic** for direct
    writes, then choose which metadata fields Tagvico may change.
 
-After saving the provider, verify the complete dependency chain. Unlike
-`/health`, this endpoint also checks the configured model provider:
+After saving the provider, inspect the detailed application health response.
+Unlike `/health`, this endpoint reports the configured model adapter's health
+when that adapter exposes a health check:
 
 ```bash
 curl --fail http://localhost:8080/api/health
 ```
+
+Some compatible and subscription-backed adapters report their health as
+unknown rather than making a billable test request. Use the **Test connection**
+actions in Settings to verify both Paperless and the selected model provider
+before processing documents.
 
 If Paperless runs on the Docker host, use `host.docker.internal` on Docker
 Desktop or the host's LAN address on Linux. If both containers share a Docker

--- a/website/versions/v2/privacy.md
+++ b/website/versions/v2/privacy.md
@@ -37,7 +37,7 @@ or disable sharing again at any time.
 
 When enabled, Tagvico sends one coarse heartbeat roughly every 24 hours. It
 contains the application version, a broad processed-count
-buckets, write mode, a broad provider category, three feature booleans, and
+bucket, write mode, a broad provider category, three feature booleans, and
 rotating daily/monthly identifiers. The locally generated secret used to derive
 those identifiers never leaves the installation, and the monthly identifier
 changes every month.

--- a/website/versions/v2/troubleshooting.md
+++ b/website/versions/v2/troubleshooting.md
@@ -10,8 +10,10 @@ curl --fail http://localhost:8080/api/health
 ```
 
 `/health` verifies the Tagvico process and its database. `/api/health` also
-probes the configured model provider and returns `503` when that dependency is
-degraded.
+reports the configured model adapter's health when the adapter exposes a
+health check, and returns `503` on an explicit failure. An `unknown` provider
+result is not a successful connection test; use the **Test connection** actions
+in Settings to verify Paperless and the selected provider.
 
 ## Setup returns 403
 


### PR DESCRIPTION
## What changed

- stop the scheduler before it contacts Paperless on an unconfigured installation
- restore Paperless metadata with an exact patch so empty original tag sets and null metadata are restored correctly
- add a regression test for exact history restoration
- clarify detailed health-check behavior and fix the v2 telemetry wording

## Why

Final v2 release validation found two runtime regressions. Fresh installs logged an unnecessary Paperless error before setup, and History restore used the normal merge-oriented update path, which could leave AI-created tags behind. The documentation also overstated provider coverage in `/api/health`.

## Impact

Fresh setup logs stay clean, History restoration now matches the saved original snapshot, and the v2 guide accurately distinguishes health reporting from explicit connection tests.

## Validation

- Node 22: typecheck, ESLint, type-debt, branding, EJS, and browser syntax checks
- 68/68 unit and persistence tests
- v2 and archived docs builds; 20 generated HTML pages with no broken internal links
- clean-image runtime smoke with migrations 1–4 and 0 production dependency vulnerabilities
- linux/amd64 and linux/arm64 Docker builds
- isolated Paperless-ngx 2.20.15 E2E: setup, permissions, synthetic ingest, review queue, apply, and exact restore
