### PR TITLE
docs: route v2 testers to feedback thread

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Share v2 test feedback
+    url: https://github.com/arturict/tagvico-ai/discussions/35
+    about: Share a redacted installation, upgrade, or workflow test result in the canonical prerelease thread.
   - name: Security vulnerability
     url: https://github.com/arturict/tagvico-ai/security/policy
     about: Please report security issues privately.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 > **Alpha — under active development.** Pin an immutable release and back up the
 > data volume before upgrades. Feedback now directly shapes the stable v2 API.
 
+**Help validate v2:** follow the [safe prerelease guidance](docs/STATUS.md),
+[share a redacted test result](https://github.com/arturict/tagvico-ai/discussions/35),
+or [report a reproducible bug](https://github.com/arturict/tagvico-ai/issues/new?template=bug_report.yml).
+Successful installation and upgrade reports are useful too.
+
 **AI-powered metadata for Paperless-ngx—self-hosted, reviewable, and compatible
 with local or hosted models.** Turn OCR text into clean titles, tags,
 correspondents, document types, dates, languages, custom fields, and optional


### PR DESCRIPTION
## Summary

- link the canonical v2 prerelease testing discussion near the README status notice
- add the same feedback destination to the issue chooser
- keep reproducible bugs and private security reports on their existing dedicated paths

## Validation

- git diff --check`n- verified all three GitHub links resolve to their intended destinations