### PR TITLE
Release Tagvico AI v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+## 2.0.0 - 2026-07-13
+
+- Promoted the reviewable Paperless-ngx filing workflow to the first stable v2
+  release after representative setup, ingest, review, apply, restore, migration,
+  Docker, and multi-architecture validation.
+- Fixed fresh installations contacting Paperless before setup was complete.
+- Fixed History restoration so it exactly replaces metadata, including clearing
+  AI-created tags and restoring null correspondent and document-type values.
+- Locked the documented v2 installation, upgrade, removal, provider, privacy,
+  and troubleshooting contract and published sanitized screenshots.
+- Kept anonymous installation analytics explicitly opt-in and off by default;
+  no official collector endpoint is embedded in v2.0.0.
+- **Upgrade note:** Back up `tagvico_ai_data`, pin
+  `ghcr.io/arturict/tagvico-ai:2.0.0`, migrate deprecated `ARCHIVISTA_*`
+  variables to `TAGVICO_*`, and validate representative documents in Review
+  first before enabling Automatic mode.
+
 ## 2.0.0-alpha.1 - 2026-07-12
 
 - Added an optional review-first workflow with durable suggestions, structured
@@ -50,7 +67,7 @@
 - Completed the strict TypeScript migration across services, routes, configuration, models, and the server; new `@ts-nocheck` suppressions are rejected by the type-debt guard.
 - Finished the Tagvico AI rebranding across shipped code, container configuration, documentation, and user-facing views.
 - Added canonical `TAGVICO_AI_PORT`, `TAGVICO_AI_HOST_PORT`, `TAGVICO_AI_VERSION`, and `TAGVICO_AI_INITIAL_SETUP` environment variables.
-- **Deprecation:** Existing `ARCHIVISTA_*` variables remain supported as warning-emitting fallbacks for compatibility and will be removed in 2.0. Deployments should migrate to `TAGVICO_*` variables now.
+- **Deprecation:** Existing `ARCHIVISTA_*` variables remain supported as warning-emitting fallbacks for compatibility. Deployments should migrate to `TAGVICO_*` variables before a future major version removes the aliases.
 
 ## 1.3.0 - 2026-07-05
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,18 @@
 # Tagvico AI
 
-> **Alpha — under active development.** Pin an immutable release and back up the
-> data volume before upgrades. Feedback now directly shapes the stable v2 API.
+> **Stable v2.0.0.** Pin an immutable release and back up the data volume before
+> upgrades. Start new installations in Review first mode before enabling writes.
 
-**Help validate v2:** follow the [safe prerelease guidance](docs/STATUS.md),
-[share a redacted test result](https://github.com/arturict/tagvico-ai/discussions/35),
+**Using v2?** Read the [stable deployment guidance](docs/STATUS.md), share a
+[redacted deployment result](https://github.com/arturict/tagvico-ai/discussions/35),
 or [report a reproducible bug](https://github.com/arturict/tagvico-ai/issues/new?template=bug_report.yml).
-Successful installation and upgrade reports are useful too.
 
 **AI-powered metadata for Paperless-ngx—self-hosted, reviewable, and compatible
 with local or hosted models.** Turn OCR text into clean titles, tags,
 correspondents, document types, dates, languages, custom fields, and optional
 owner assignments while keeping control of the model and privacy boundary.
 
-[![Status: Alpha](https://img.shields.io/badge/status-alpha-ff6f00.svg)](docs/STATUS.md)
+[![Status: Stable](https://img.shields.io/badge/status-stable-2ea44f.svg)](docs/STATUS.md)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/arturict/tagvico-ai)](https://github.com/arturict/tagvico-ai/releases)
 [![CI](https://img.shields.io/github/actions/workflow/status/arturict/tagvico-ai/ci.yml?branch=main&label=CI)](https://github.com/arturict/tagvico-ai/actions/workflows/ci.yml)
@@ -63,7 +62,7 @@ services:
   tagvico-ai:
     # Pin an immutable release tag for upgrades you can rely on.
     # See https://github.com/arturict/tagvico-ai/releases for the current version.
-    image: ghcr.io/arturict/tagvico-ai:2.0.0-alpha.1
+    image: ghcr.io/arturict/tagvico-ai:2.0.0
     container_name: tagvico-ai
     restart: unless-stopped
     cap_drop:
@@ -111,7 +110,7 @@ docker run -d \
   -p 8080:3000 \
   -e TAGVICO_AI_PORT=3000 \
   -v tagvico_ai_data:/app/data \
-  ghcr.io/arturict/tagvico-ai:2.0.0-alpha.1
+  ghcr.io/arturict/tagvico-ai:2.0.0
 ```
 
 </details>
@@ -166,7 +165,7 @@ Copy [`.env.example`](.env.example) when deploying without the setup wizard. Var
 
 Set `TAGVICO_WRITE_MODE=review` to queue suggestions or `TAGVICO_WRITE_MODE=automatic` for direct writes. The setup and settings pages expose the same two choices. `DRY_RUN=true/false` remains supported for older deployments, but the explicit write-mode variable takes precedence.
 
-The canonical application variables are `TAGVICO_AI_PORT`, `TAGVICO_AI_HOST_PORT`, `TAGVICO_AI_VERSION`, and `TAGVICO_AI_INITIAL_SETUP`. Their former `ARCHIVISTA_*` names remain supported as deprecated fallbacks for existing deployments and emit a warning when used. Migrate to the `TAGVICO_*` names before the legacy aliases are removed in 2.0.
+The canonical application variables are `TAGVICO_AI_PORT`, `TAGVICO_AI_HOST_PORT`, `TAGVICO_AI_VERSION`, and `TAGVICO_AI_INITIAL_SETUP`. Their former `ARCHIVISTA_*` names remain supported as deprecated fallbacks for existing deployments and emit a warning when used. Migrate to the `TAGVICO_*` names before a future major version removes the aliases.
 
 ### OCR rescue and failure recovery
 
@@ -177,7 +176,7 @@ History supports explicit rescan and restoration of the first metadata snapshot 
 ## Upgrades
 
 1. Check the latest release at <https://github.com/arturict/tagvico-ai/releases>.
-2. Update the image tag in `docker-compose.yml` to the new **immutable version tag** shown on the releases page—for example `ghcr.io/arturict/tagvico-ai:2.0.0-alpha.1`. Avoid `:latest` in production: it makes rollback ambiguous and can pull a breaking change unexpectedly.
+2. Update the image tag in `docker-compose.yml` to the new **immutable version tag** shown on the releases page—for example `ghcr.io/arturict/tagvico-ai:2.0.0`. Avoid `:latest` in production: it makes rollback ambiguous and can pull a breaking change unexpectedly.
 3. `docker compose pull && docker compose up -d`.
 
 Tagvico is stateless across restarts: configuration, processing history, and the local admin account live in the `tagvico_ai_data` volume, so upgrades do not touch your settings.
@@ -224,7 +223,7 @@ The development server listens on `http://localhost:3000`. The application sourc
 
 Bug reports, feature requests, and pull requests are welcome. The issue chooser asks only for the information needed to reproduce or evaluate a change, and the pull-request template includes a short verification checklist. See [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow. For security disclosures, follow [SECURITY.md](SECURITY.md) instead of opening a public issue.
 
-See [docs/STATUS.md](docs/STATUS.md) for the current development status, what may still change before stable v2, and recommendations for running the v2 prerelease.
+See [docs/STATUS.md](docs/STATUS.md) for the v2 compatibility policy and stable deployment recommendations.
 
 ## License
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,7 +7,7 @@ directory and served by Coolify at `https://tagvico.arturf.ch/docs/`.
 | File / directory | Purpose |
 | --- | --- |
 | `index.html` | Standalone landing page (the public docs site). |
-| `STATUS.md` | Current development status, alpha expectations, upgrade guidance. |
+| `STATUS.md` | Current development status, compatibility policy, upgrade guidance. |
 | `screenshots/` | Product screenshots used in the README and landing page. |
 | `providers/` | Per-provider setup and troubleshooting guides. |
 | `V2_COMPETITIVE_REVIEW.md` | Source-level v2 feature comparison and release gates. |

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,51 +1,45 @@
 # Project status
 
-**Status:** v2 prerelease (`2.0.0-alpha.1`) — under active testing.
+**Status:** stable v2 (`2.0.0`).
 
-## What this means
+## Stable v2 contract
 
-Tagvico AI v2 is in **prerelease testing**. The TypeScript migration and core
-review-first filing workflow are complete, but the following may still change
-before stable `2.0.0`:
+Tagvico AI v2.0.0 is the first stable release of the reviewable Paperless-ngx
+filing workflow. The following are compatibility commitments for v2:
 
-- The HTTP/REST API surface (paths, request bodies, response fields).
-- The configuration schema in `data/.env` and the setup wizard.
-- The SQLite database schema in `data/tagvico.db` (migrations are provided, but backwards compatibility is not guaranteed across v2 prereleases).
-- Provider adapter behavior (Ollama, OpenAI, OpenRouter, Azure OpenAI, OpenAI-compatible, Anthropic, experimental Codex sign-in).
-- Default values, output formats, and confidence thresholds.
-- File paths, filenames, and the on-disk layout inside the persistent volume.
+- Existing v2 data volumes are upgraded with versioned, idempotent SQLite
+  migrations and a pre-migration database backup.
+- Canonical `TAGVICO_*` environment variables, port `3000`, `/app/data`, and
+  the documented setup, login, health, review, history, and settings workflows
+  remain supported throughout v2.
+- Stable upgrades do not intentionally discard the local admin account,
+  settings, processing history, review queue, or original metadata snapshots.
+- Paperless data is accessed only through the official Paperless REST API.
 
-## Recommendations for prerelease users
+Breaking changes to these contracts require a new major version. Provider
+model names, prices, quotas, and account entitlements remain controlled by the
+provider and can change independently of Tagvico.
 
-- **Pin a specific release tag** in `docker-compose.yml` (for example `ghcr.io/arturict/tagvico-ai:<version>`), never `:latest`. We publish immutable tags per release.
-- **Back up the `tagvico_ai_data` volume** before upgrading. The volume holds your admin account, provider settings, and processing history.
-- **Test upgrades on a non-production instance** if you rely on automatic metadata writes.
-- **Read the release notes** for breaking changes — they are documented per release on the [GitHub releases page](https://github.com/arturict/tagvico-ai/releases).
+## Recommended deployment policy
 
-## What is stable enough to rely on
+- Pin `ghcr.io/arturict/tagvico-ai:2.0.0` rather than `latest` when you need
+  explicit change control and unambiguous rollback.
+- Back up the complete `tagvico_ai_data` volume before every upgrade.
+- Start in **Review first** and test representative, non-sensitive documents
+  before enabling Automatic mode.
+- Treat ChatGPT subscription access as experimental and account-specific; it is
+  not an API SLA.
+- Keep anonymous installation analytics disabled unless you explicitly choose
+  to share the locally previewed aggregate heartbeat.
 
-- The Docker image contract: same env vars, same port, same persistent volume path.
-- The setup wizard flow (browser-based onboarding at `/setup`).
-- The Paperless-ngx integration: we only write to the official Paperless REST API, and we never modify your Paperless database directly.
-- The local admin account: the SQLite-stored credentials in the persistent volume.
-- The OpenAI-compatible provider contract: anything that speaks the OpenAI Chat Completions API works the same way.
+## Security and support
 
-## Reporting prerelease issues
+Report reproducible bugs through the
+[issue tracker](https://github.com/arturict/tagvico-ai/issues) after removing
+credentials, private URLs, document contents, and personal information.
+Security issues must not be filed publicly; follow
+[`SECURITY.md`](../SECURITY.md).
 
-The prerelease window is where feedback is most useful. Please file issues for:
-
-- Surprising behavior or errors during setup.
-- Provider failures, malformed responses, or token-limit issues.
-- Database migration errors when upgrading from an earlier version.
-- Anything you would expect to be configurable but cannot find.
-
-Security issues must **not** be filed as public issues — see [SECURITY.md](../SECURITY.md).
-
-## Roadmap toward stable v2
-
-- [x] Complete the TypeScript migration of all services and routes.
-- Lock the REST API surface, configuration schema, and database schema.
-- Complete representative Paperless ingest, restore, OCR, and provider-account
-  checks, then tag stable `2.0.0`.
-
-This document lives at `docs/STATUS.md` and is updated when the project status changes.
+Release-specific upgrade and rollback instructions are available on the
+[GitHub releases page](https://github.com/arturict/tagvico-ai/releases) and in
+the [versioned v2 documentation](https://tagvico.arturf.ch/docs/).

--- a/docs/index.html
+++ b/docs/index.html
@@ -411,8 +411,8 @@
         </nav>
       </div>
       <div class="alpha-strip" role="status" aria-label="Project status">
-        <span class="alpha-pill">ALPHA</span>
-        <span>Tagvico AI is under active development. APIs and the configuration schema may change without notice &mdash; pin a release tag for stability.</span>
+        <span class="alpha-pill">STABLE V2</span>
+        <span>Tagvico AI v2.0.0 is stable. Pin the immutable release tag and back up the data volume before upgrades.</span>
       </div>
     </header>
 
@@ -421,7 +421,7 @@
       <div class="hero">
         <div class="container">
           <div class="hero-badges">
-            <img src="https://img.shields.io/badge/status-ALPHA-ff6f00.svg" alt="Status: Alpha">
+            <img src="https://img.shields.io/badge/status-stable-2ea44f.svg" alt="Status: Stable">
             <a href="https://github.com/arturict/tagvico-ai/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="MIT License"></a>
             <a href="https://github.com/arturict/tagvico-ai/releases"><img src="https://img.shields.io/github/v/release/arturict/tagvico-ai" alt="Latest release"></a>
             <a href="https://github.com/arturict/tagvico-ai/actions/workflows/ci.yml"><img src="https://img.shields.io/github/actions/workflow/status/arturict/tagvico-ai/ci.yml?branch=main&label=CI" alt="CI"></a>
@@ -453,7 +453,7 @@
               <p>Save as <code>docker-compose.yml</code> and bring up the stack:</p>
 <pre><code>services:
   tagvico-ai:
-    image: ghcr.io/arturict/tagvico-ai:latest
+    image: ghcr.io/arturict/tagvico-ai:2.0.0
     container_name: tagvico-ai
     restart: unless-stopped
     ports:
@@ -484,7 +484,7 @@ volumes:
   -e AI_PROVIDER=openai \
   -e OPENAI_API_KEY=sk-... \
   -v tagvico_ai_data:/app/data \
-  ghcr.io/arturict/tagvico-ai:latest</code></pre>
+  ghcr.io/arturict/tagvico-ai:2.0.0</code></pre>
               <div class="copy-row">
                 <button class="copy-btn" data-copy="oneliner" type="button">Copy</button>
               </div>
@@ -575,7 +575,7 @@ volumes:
       const snippets = {
         compose: `services:
   tagvico-ai:
-    image: ghcr.io/arturict/tagvico-ai:latest
+    image: ghcr.io/arturict/tagvico-ai:2.0.0
     container_name: tagvico-ai
     restart: unless-stopped
     ports:
@@ -597,7 +597,7 @@ volumes:
   -e AI_PROVIDER=openai \\
   -e OPENAI_API_KEY=sk-... \\
   -v tagvico_ai_data:/app/data \\
-  ghcr.io/arturict/tagvico-ai:latest`
+  ghcr.io/arturict/tagvico-ai:2.0.0`
       };
 
       document.querySelectorAll('.copy-btn').forEach(btn => {

--- a/docs/launch-post.md
+++ b/docs/launch-post.md
@@ -17,8 +17,8 @@ queue, generated tags can be constrained to a controlled vocabulary, and local
 Ollama or an OpenAI-compatible endpoint can keep classification on your own
 network. Hosted providers are optional and explicit.
 
-It runs in Docker, is MIT licensed, and is still alpha—pin a release, back up
-the volume, and start in Review-first mode.
+Version 2.0 is stable, runs in Docker, and is MIT licensed. Pin the release,
+back up the volume, and start in Review-first mode.
 
 GitHub: https://github.com/arturict/tagvico-ai
 
@@ -40,9 +40,10 @@ Tagvico-operated service.
 
 Repository and Compose example: https://github.com/arturict/tagvico-ai
 
-The project is alpha. I would like blunt Paperless-specific feedback: does the
-review queue fit your workflow, which fields should default to existing values
-only, and what would make you trust automatic mode?
+Version 2.0 is the first stable release. I would still value blunt
+Paperless-specific feedback: does the review queue fit your workflow, which
+fields should default to existing values only, and what would make you trust
+automatic mode?
 
 ## Show HN
 
@@ -53,7 +54,7 @@ and proposes structured document metadata. The main design goal is a visible
 safety boundary: reviewable diffs, controlled vocabularies, restoration, local
 model support, and optional hosted providers instead of a mandatory cloud.
 
-It is TypeScript, Docker, SQLite, and MIT licensed. The project is alpha and I
+It is TypeScript, Docker, SQLite, and MIT licensed. Version 2.0 is stable, and I
 am looking for feedback from people running real document archives.
 
 https://github.com/arturict/tagvico-ai

--- a/docs/releases/v2.0.0.md
+++ b/docs/releases/v2.0.0.md
@@ -1,0 +1,49 @@
+# Tagvico AI v2.0.0
+
+Tagvico AI v2.0.0 is the first stable release of the self-hosted, reviewable
+AI filing workflow for Paperless-ngx.
+
+## Highlights
+
+- Queue durable metadata suggestions for review or enable validated automatic
+  writes per installation.
+- Apply or reject structured diffs and restore the first metadata snapshot,
+  including exact tag, correspondent, document-type, date, language, custom
+  field, and owner values.
+- Constrain generated tags with controlled groups, per-document caps, and an
+  exception queue.
+- Use Ollama, Ollama Cloud, OpenAI, Anthropic, OpenRouter, OpenCode Go, Azure
+  OpenAI, GitHub Copilot, OpenAI-compatible gateways, or experimental ChatGPT
+  subscription access.
+- Recover OCR-poor documents, interrupted work, retries, and terminal failures
+  from durable queues.
+- Inspect processing history, token usage, estimated cost, runner state, and
+  provider health from the web interface.
+- Optionally share a coarse installation heartbeat. Analytics are off by
+  default, the exact payload is locally previewable, identifiers rotate, and
+  no official collector endpoint is embedded.
+
+## Upgrade from v1 or the v2 alpha
+
+1. Stop Tagvico and back up the complete `tagvico_ai_data` volume.
+2. Replace deprecated pre-Tagvico environment variables with their documented
+   `TAGVICO_*` equivalents.
+3. Pin `ghcr.io/arturict/tagvico-ai:2.0.0` in Compose.
+4. Start the container and verify both `/health` and `/api/health`.
+5. Sign in, test the Paperless and model-provider connections, and process a
+   representative non-sensitive document in **Review first**.
+6. Enable Automatic mode only after reviewing the resulting metadata.
+
+Do not run two Tagvico versions against the same data volume. Restore the
+volume backup before rolling back if a newer version migrated the database.
+
+## Stable boundaries
+
+- The v2 Docker, persistent-volume, canonical environment-variable, migration,
+  setup, review, history, and restore contracts are stable.
+- ChatGPT subscription access remains experimental and account-specific.
+- Model catalogs, pricing, quotas, and entitlements remain provider-controlled.
+- Compatible and subscription-backed adapters may report provider health as
+  unknown; use the explicit connection tests in Settings before processing.
+
+Full documentation: https://tagvico.arturf.ch/docs/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tagvico-ai",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tagvico-ai",
-      "version": "2.0.0-alpha.1",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.109.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tagvico-ai",
-  "version": "2.0.0-alpha.1",
-  "description": "Tagvico AI — alpha. Self-hosted AI autopilot for Paperless-ngx (metadata, tagging, classification, owner assignment). Active development; APIs and schema may change without notice.",
+  "version": "2.0.0",
+  "description": "Tagvico AI — self-hosted, reviewable AI filing for Paperless-ngx (metadata, tagging, classification, and owner assignment).",
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24"
   },

--- a/website/versions/v2/index.md
+++ b/website/versions/v2/index.md
@@ -45,7 +45,8 @@ The v2 documentation is frozen under this URL when a future major version is
 published. Use the version menu in the navigation to move between major
 versions without losing the instructions that match your installation.
 
-::: warning Alpha documentation
-The current package is a v2 alpha. Pin an immutable image version, back up the
-data volume before upgrades, and start in **Review first** mode.
+::: tip Stable v2
+Version 2.0.0 is the first stable v2 release. Pin the immutable image version,
+back up the data volume before upgrades, and start new installations in
+**Review first** mode.
 :::

--- a/website/versions/v2/installation.md
+++ b/website/versions/v2/installation.md
@@ -11,7 +11,7 @@ Create a new directory and save this as `docker-compose.yml`:
 ```yaml
 services:
   tagvico-ai:
-    image: ghcr.io/arturict/tagvico-ai:2.0.0-alpha.1
+    image: ghcr.io/arturict/tagvico-ai:2.0.0
     container_name: tagvico-ai
     restart: unless-stopped
     cap_drop:
@@ -92,7 +92,7 @@ docker run -d \
   -e TAGVICO_AI_PORT=3000 \
   -e ALLOW_REMOTE_SETUP=yes \
   -v tagvico_ai_data:/app/data \
-  ghcr.io/arturict/tagvico-ai:2.0.0-alpha.1
+  ghcr.io/arturict/tagvico-ai:2.0.0
 ```
 
 After setup, remove `ALLOW_REMOTE_SETUP=yes` unless you specifically need to


### PR DESCRIPTION
## What changed

- set the package and lockfile version to stable `2.0.0`
- add stable v2 changelog and release notes with upgrade and rollback guidance
- replace prerelease language and alpha badges in the README, status page, landing page, launch copy, and versioned v2 docs
- pin installation examples to `ghcr.io/arturict/tagvico-ai:2.0.0`
- document the v2 compatibility contract and keep account-bound providers explicitly experimental where applicable

## Why

The v2 alpha completed its release checklist, including the PR #31 startup and exact-restore fixes. This commit turns that validated codebase into the first stable v2 release without changing runtime behavior after the final test pass.

## Impact

Users get an immutable stable image tag, a clear upgrade path from v1 or the alpha, a documented v2 support boundary, and consistent stable messaging across all maintained documentation surfaces.

## Validation

- clean Node 22 install
- full quality gate and 68/68 tests
- both versioned documentation builds and 20-page internal-link check
- final screenshot pixel/privacy inspection
- production dependency audit: 0 vulnerabilities
- fresh-volume runtime smoke with migrations 1–4, `/health`, and `/setup`
- Docker builds for linux/amd64 and linux/arm64
- release image reports package version `2.0.0`
