### PR TITLE
fix: prevent configured setup takeover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+## 2.0.1 - 2026-07-21
+
+### Security and privacy
+
+- Reject public `POST /setup` requests once setup has completed, before any
+  Paperless connection check or configuration write. Change existing settings
+  only after signing in.
+
 ### Added
 
 - Add an optional, private-chat-only Telegram interface for allowlisted users. Each Telegram ID uses its own Paperless API token for search, cited-original downloads, and PDF/photo uploads.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tagvico AI
 
-> **Stable v2.0.0.** Pin an immutable release and back up the data volume before
+> **Stable v2.0.1.** Pin an immutable release and back up the data volume before
 > upgrades. Start new installations in Review first mode before enabling writes.
 
 **Using v2?** Read the [stable deployment guidance](docs/STATUS.md), share a
@@ -63,7 +63,7 @@ services:
   tagvico-ai:
     # Pin an immutable release tag for upgrades you can rely on.
     # See https://github.com/arturict/tagvico-ai/releases for the current version.
-    image: ghcr.io/arturict/tagvico-ai:2.0.0
+    image: ghcr.io/arturict/tagvico-ai:2.0.1
     container_name: tagvico-ai
     restart: unless-stopped
     cap_drop:
@@ -111,7 +111,7 @@ docker run -d \
   -p 8080:3000 \
   -e TAGVICO_AI_PORT=3000 \
   -v tagvico_ai_data:/app/data \
-  ghcr.io/arturict/tagvico-ai:2.0.0
+  ghcr.io/arturict/tagvico-ai:2.0.1
 ```
 
 </details>
@@ -199,7 +199,7 @@ History supports explicit rescan and restoration of the first metadata snapshot 
 ## Upgrades
 
 1. Check the latest release at <https://github.com/arturict/tagvico-ai/releases>.
-2. Update the image tag in `docker-compose.yml` to the new **immutable version tag** shown on the releases page—for example `ghcr.io/arturict/tagvico-ai:2.0.0`. Avoid `:latest` in production: it makes rollback ambiguous and can pull a breaking change unexpectedly.
+2. Update the image tag in `docker-compose.yml` to the new **immutable version tag** shown on the releases page—for example `ghcr.io/arturict/tagvico-ai:2.0.1`. Avoid `:latest` in production: it makes rollback ambiguous and can pull a breaking change unexpectedly.
 3. `docker compose pull && docker compose up -d`.
 
 Tagvico is stateless across restarts: configuration, processing history, and the local admin account live in the `tagvico_ai_data` volume, so upgrades do not touch your settings.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tagvico-ai",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tagvico-ai",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT",
       "dependencies": {
         "@anthropic-ai/sdk": "^0.109.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tagvico-ai",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Tagvico AI — self-hosted, reviewable AI filing for Paperless-ngx (metadata, tagging, classification, and owner assignment).",
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || >=24"

--- a/routes/setup.ts
+++ b/routes/setup.ts
@@ -3808,6 +3808,16 @@ router.get('/api/health', async (req: Req, res: Res) => {
  */
 router.post('/setup', express.json(), async (req: Req, res: Res) => {
   try {
+    // Setup is deliberately one-time. This route is public only for the first
+    // local (or explicitly opted-in remote) bootstrap; accepting it after a
+    // configuration exists would let an unauthenticated caller replace the
+    // admin account and connection settings.
+    if (await setupService.isConfigured()) {
+      return res.status(409).json({
+        error: 'Setup has already been completed. Sign in to change settings.'
+      });
+    }
+
     const { 
       paperlessUrl, 
       paperlessToken,

--- a/tests/security.test.js
+++ b/tests/security.test.js
@@ -1,5 +1,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const totp = require('../dist/services/totpService');
 const { createRateLimiter } = require('../dist/services/rateLimiter');
@@ -25,4 +27,19 @@ test('rate limiter returns 429 after the configured allowance', () => {
   limiter(req, response, () => { nextCalls += 1; });
   assert.equal(nextCalls, 1);
   assert.equal(response.statusCode, 429);
+});
+
+test('configured instances reject public setup mutations before processing credentials', () => {
+  const root = path.join(__dirname, '..');
+  const source = fs.readFileSync(path.join(root, 'routes', 'setup.ts'), 'utf8');
+  const start = source.indexOf("router.post('/setup'");
+  const handler = source.slice(start, start + 9000);
+
+  assert.match(handler, /if \(await setupService\.isConfigured\(\)\)/);
+  assert.match(handler, /res\.status\(409\)\.json/);
+  assert.match(handler, /Setup has already been completed/);
+  assert.ok(
+    handler.indexOf('await setupService.isConfigured()') < handler.indexOf('initializeWithCredentials'),
+    'configured instances must reject setup before validating or writing replacement credentials'
+  );
 });

--- a/website/versions/v2/index.md
+++ b/website/versions/v2/index.md
@@ -49,7 +49,7 @@ published. Use the version menu in the navigation to move between major
 versions without losing the instructions that match your installation.
 
 ::: tip Stable v2
-Version 2.0.0 is the first stable v2 release. Pin the immutable image version,
+Version 2.0.1 is the current stable v2 release. Pin the immutable image version,
 back up the data volume before upgrades, and start new installations in
 **Review first** mode.
 :::

--- a/website/versions/v2/installation.md
+++ b/website/versions/v2/installation.md
@@ -11,7 +11,7 @@ Create a new directory and save this as `docker-compose.yml`:
 ```yaml
 services:
   tagvico-ai:
-    image: ghcr.io/arturict/tagvico-ai:2.0.0
+    image: ghcr.io/arturict/tagvico-ai:2.0.1
     container_name: tagvico-ai
     restart: unless-stopped
     cap_drop:
@@ -22,7 +22,6 @@ services:
       - "8080:3000"
     environment:
       TAGVICO_AI_PORT: "3000"
-      ALLOW_REMOTE_SETUP: "yes"
     volumes:
       - tagvico_ai_data:/app/data
 
@@ -42,6 +41,11 @@ curl http://localhost:8080/health
 ```
 
 Open `http://localhost:8080/setup` after the health check succeeds.
+
+If the setup browser is on a different machine, temporarily add
+`ALLOW_REMOTE_SETUP: "yes"` to the service environment, recreate the
+container, and remove it immediately after the first setup completes. Do not
+leave it enabled for normal operation.
 
 ![Tagvico AI v2 sign-in screen captured from a clean VM 113 browser session](/screenshots/sign-in.png)
 
@@ -122,13 +126,13 @@ docker run -d \
   --security-opt no-new-privileges=true \
   -p 8080:3000 \
   -e TAGVICO_AI_PORT=3000 \
-  -e ALLOW_REMOTE_SETUP=yes \
   -v tagvico_ai_data:/app/data \
-  ghcr.io/arturict/tagvico-ai:2.0.0
+  ghcr.io/arturict/tagvico-ai:2.0.1
 ```
 
-After setup, remove `ALLOW_REMOTE_SETUP=yes` unless you specifically need to
-repeat setup from another machine.
+Setup is a one-time bootstrap; later configuration changes require signing in.
+For a remote browser, add `-e ALLOW_REMOTE_SETUP=yes` only until setup is
+finished, then recreate the container without it.
 
 ## Next steps
 

--- a/website/versions/v2/troubleshooting.md
+++ b/website/versions/v2/troubleshooting.md
@@ -22,6 +22,13 @@ same machine as Tagvico, temporarily set `ALLOW_REMOTE_SETUP=yes`, recreate the
 container, and complete setup. Remove the setting afterward and recreate the
 container again.
 
+## Setup returns 409
+
+The instance already has setup data. This is intentional: public setup cannot
+replace an existing admin account or its connection settings. Sign in and use
+Settings for normal changes. For disaster recovery, restore a known-good data
+volume backup rather than exposing a reset endpoint.
+
 ## Paperless connection fails
 
 - Use the Paperless base URL without `/api`.

--- a/website/versions/v2/upgrading.md
+++ b/website/versions/v2/upgrading.md
@@ -40,9 +40,24 @@ schema upgrades. The external volume backup remains the safest rollback point.
 
 ## Roll back
 
-Stop the new container, restore the backup volume if the upgrade changed its
-schema, pin the previous image tag, and start Compose again. Do not run two
-Tagvico versions against the same volume at the same time.
+Use this only with the external backup made above. Do not run two Tagvico
+versions against the same volume at the same time.
+
+```bash
+docker compose down
+docker volume rm tagvico_ai_data
+docker volume create tagvico_ai_data
+docker run --rm \
+  -v tagvico_ai_data:/target \
+  -v "$PWD":/backup:ro \
+  alpine sh -c 'tar xzf /backup/tagvico-ai-data.tgz -C /target'
+# Change image: back to the previous immutable release tag, then:
+docker compose up -d
+docker compose logs --tail=100 tagvico-ai
+```
+
+Confirm that `/health`, sign-in, configuration, and one representative
+**Review first** suggestion work before returning to normal operation.
 
 ::: danger v1 to v2
 Treat a major-version upgrade as a maintenance window. Back up the volume,


### PR DESCRIPTION
## v2.0.1 security release

- rejects a public `POST /setup` after configuration is present, before credential validation or writes
- adds regression coverage and a direct HTTP verification
- updates the immutable image tag and v2 installation, troubleshooting, and rollback documentation

Validation (Node 22):
- `npm run check`
- `npm run test` — 84 passing
- `npm run docs:build`