### PR TITLE
fix: filter embedding models from Ask Tagvico

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.1.2 - 2026-07-24
+
+### Ask Tagvico
+
+- Exclude provider model IDs containing colon- or slash-delimited embedding
+  markers, including Ollama models such as `qwen3-embedding:4b` and
+  `nomic-embed-text:latest`, from every chat model picker.
+
 ## 3.1.1 - 2026-07-24
 
 ### Providers and Companion

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ which account-scoped model is active, and which vocabulary the model may use.
 
 <p align="center"><em>Sanitized screens from the established document-automation interface. Live document names were replaced for privacy.</em></p>
 
-## Stable quick start (v3.1.1)
+## Stable quick start (v3.1.2)
 
 Use only immutable tags that are present on the
 [GitHub releases page](https://github.com/arturict/tagvico-ai/releases).
@@ -76,7 +76,7 @@ services:
   tagvico-ai:
     # Pin an immutable release tag for upgrades you can rely on.
     # See https://github.com/arturict/tagvico-ai/releases for the current version.
-    image: ghcr.io/arturict/tagvico-ai:3.1.1
+    image: ghcr.io/arturict/tagvico-ai:3.1.2
     container_name: tagvico-ai
     restart: unless-stopped
     cap_drop:
@@ -129,7 +129,7 @@ docker run -d \
   -e TAGVICO_AI_PORT=3000 \
   -e ALLOW_REMOTE_SETUP=yes \
   -v tagvico_ai_data:/app/data \
-  ghcr.io/arturict/tagvico-ai:3.1.1
+  ghcr.io/arturict/tagvico-ai:3.1.2
 ```
 
 After setup succeeds, remove and recreate the container without
@@ -219,7 +219,7 @@ Activity supports single and bulk rescan, exact restoration of the first metadat
 ## Upgrades
 
 1. Check the latest release at <https://github.com/arturict/tagvico-ai/releases>.
-2. Update the image tag in `docker-compose.yml` to the new **immutable version tag** shown on the releases page—for example `ghcr.io/arturict/tagvico-ai:3.1.1`. Avoid `:latest` in production: it makes rollback ambiguous and can pull a breaking change unexpectedly.
+2. Update the image tag in `docker-compose.yml` to the new **immutable version tag** shown on the releases page—for example `ghcr.io/arturict/tagvico-ai:3.1.2`. Avoid `:latest` in production: it makes rollback ambiguous and can pull a breaking change unexpectedly.
 3. `docker compose pull && docker compose up -d`.
 
 The container is replaceable, while configuration, processing history, the local admin account, encrypted member tokens, and the installation secret live in the `tagvico_ai_data` volume. Back up and restore that volume as one unit; changing or losing the JWT secret makes encrypted member tokens unreadable.

--- a/config/config.ts
+++ b/config/config.ts
@@ -11,7 +11,7 @@ const { resolveDataDirectory } = require('../services/dataDirectory');
 const { applyPersistedAiSelection } = require('../services/managedAiSelection');
 const currentDir = decodeURIComponent(process.cwd());
 const dataDir = resolveDataDirectory();
-let packageVersion = '3.1.1';
+let packageVersion = '3.1.2';
 try {
   packageVersion = JSON.parse(fs.readFileSync(path.join(/*turbopackIgnore: true*/ process.cwd(), 'package.json'), 'utf8')).version || packageVersion;
 } catch {

--- a/docs/releases/v3.1.2.md
+++ b/docs/releases/v3.1.2.md
@@ -1,0 +1,17 @@
+# Tagvico AI v3.1.2
+
+Tagvico 3.1.2 is a focused Ask Tagvico model-picker hotfix.
+
+## What changed
+
+- Embedding-only models from live provider catalogs are no longer offered as
+  chat models, including colon-delimited Ollama IDs such as
+  `qwen3-embedding:4b`.
+- The filter also covers common `embed` model names and provider IDs using
+  slash-delimited segments.
+
+## Upgrade
+
+Back up `tagvico_ai_data`, pin
+`ghcr.io/arturict/tagvico-ai:3.1.2`, and recreate only the Tagvico container.
+No settings or data migration is required.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tagvico-ai",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tagvico-ai",
-      "version": "3.1.1",
+      "version": "3.1.2",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai": "3.0.86",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tagvico-ai",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Tagvico — the private action center and household companion for Paperless-ngx.",
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || ^24.0.0"

--- a/routes/setup.ts
+++ b/routes/setup.ts
@@ -3081,7 +3081,7 @@ router.get('/api/dashboard', async (_req: Req, res: Res) => {
     res.json({
       summary,
       processing,
-      version: configFile.TAGVICO_AI_VERSION || '3.1.1'
+      version: configFile.TAGVICO_AI_VERSION || '3.1.2'
     });
   } catch (error) {
     console.error('[ERROR] loading dashboard data:', error);
@@ -4609,7 +4609,7 @@ router.get('/api/operations/status', async (_req: Req, res: Res) => {
   res.json({
     ocrEnabled: ocrService.isEnabled(),
     ocrProvider: config.ocr?.provider || 'mistral',
-    version: configFile.TAGVICO_AI_VERSION || '3.1.1'
+    version: configFile.TAGVICO_AI_VERSION || '3.1.2'
   });
 });
 

--- a/services/codexAuthService.ts
+++ b/services/codexAuthService.ts
@@ -152,7 +152,7 @@ class CodexAuthService {
       child.stdin.write(`${JSON.stringify({
         id: 1,
         method: 'initialize',
-        params: { clientInfo: { name: 'tagvico', title: 'Tagvico', version: '3.1.1' } }
+        params: { clientInfo: { name: 'tagvico', title: 'Tagvico', version: '3.1.2' } }
       })}\n`);
     });
   }

--- a/services/companionModelService.ts
+++ b/services/companionModelService.ts
@@ -20,7 +20,7 @@ const SUPPORTED_ADAPTERS = new Set([
   'native-ollama'
 ]);
 const CACHE_TTL_MS = 60_000;
-const NON_CHAT_MODEL_ID = /(?:^|[-_.])(?:embedding|embeddings|whisper|tts|moderation|realtime|audio|transcribe|transcription|image|vision-only|sora)(?:$|[-_.])/i;
+const NON_CHAT_MODEL_ID = /(?:^|[-_.:/])(?:embed(?:ding)?s?\d*|whisper|tts|moderation|realtime|audio|transcribe|transcription|image|vision-only|sora)(?:$|[-_.:/])/i;
 const LEGACY_COMPLETION_MODEL_ID = /^(?:text-|davinci(?:-|$)|babbage(?:-|$)|curie(?:-|$)|ada(?:-|$))/i;
 
 let cachedCatalog: {

--- a/services/settingsV3Service.ts
+++ b/services/settingsV3Service.ts
@@ -321,7 +321,7 @@ async function getSettings() {
       customFields: customFields(effective.CUSTOM_FIELDS)
     },
     diagnostics: {
-      version: effective.TAGVICO_AI_VERSION || '3.1.1',
+      version: effective.TAGVICO_AI_VERSION || '3.1.2',
       configured: yes(effective.TAGVICO_AI_INITIAL_SETUP),
       providerRegistrySize: knownDefinitions.length
     }

--- a/src/lib/changelog.ts
+++ b/src/lib/changelog.ts
@@ -9,6 +9,22 @@ export type ChangelogEntry = {
 
 export const changelogEntries: ChangelogEntry[] = [
   {
+    version: '3.1.2',
+    date: '24 July 2026',
+    title: 'Chat-only model catalogs',
+    summary: 'A focused hotfix that keeps embedding-only provider models out of Ask Tagvico.',
+    status: 'released',
+    groups: [
+      {
+        title: 'Ask Tagvico',
+        items: [
+          'Embedding-only models with colon-, slash-, dash-, dot- or underscore-delimited IDs are no longer offered in chat model pickers.',
+          'Ollama IDs such as qwen3-embedding:4b and nomic-embed-text:latest are covered by regression tests.'
+        ]
+      }
+    ]
+  },
+  {
     version: '3.1.1',
     date: '24 July 2026',
     title: 'Reliable automation and a useful Paperless copilot',
@@ -87,4 +103,4 @@ export const changelogEntries: ChangelogEntry[] = [
   }
 ];
 
-export const currentChangelogAnnouncement = changelogEntries.find((entry) => entry.version === '3.1.1')!;
+export const currentChangelogAnnouncement = changelogEntries.find((entry) => entry.version === '3.1.2')!;

--- a/tests/companion-models.test.js
+++ b/tests/companion-models.test.js
@@ -54,7 +54,19 @@ test('Companion rejects stale or invented models and falls back to a runtime def
 });
 
 test('Companion excludes live catalog entries that cannot answer chat requests', () => {
-  for (const id of ['text-embedding-3-small', 'whisper-1', 'tts-1', 'omni-moderation-latest', 'gpt-image-2', 'gpt-realtime-2', 'sora-2']) {
+  for (const id of [
+    'text-embedding-3-small',
+    'qwen3-embedding:4b',
+    'nomic-embed-text:latest',
+    'mxbai-embed-large',
+    'snowflake-arctic-embed2:latest',
+    'whisper-1',
+    'tts-1',
+    'omni-moderation-latest',
+    'gpt-image-2',
+    'gpt-realtime-2',
+    'sora-2'
+  ]) {
     assert.equal(modelService.supportsCompanionModel({ id }), false, id);
   }
   for (const id of ['gpt-5.6-terra', 'claude-sonnet-4.6', 'gemma3:latest', 'gpt-4o-search-preview']) {

--- a/website/versions/v3/index.md
+++ b/website/versions/v3/index.md
@@ -49,7 +49,7 @@ published. Use the version menu in the navigation to move between major
 versions without losing the instructions that match your installation.
 
 ::: tip Production defaults
-Pin the immutable `3.1.1` image after the release is published, back up the data volume before upgrades, and start new installations in
+Pin the immutable `3.1.2` image after the release is published, back up the data volume before upgrades, and start new installations in
 **Review first** mode. Companion writes are always approval-gated regardless
 of the metadata processing mode.
 :::

--- a/website/versions/v3/installation.md
+++ b/website/versions/v3/installation.md
@@ -11,7 +11,7 @@ Create a new directory and save this as `docker-compose.yml`:
 ```yaml
 services:
   tagvico-ai:
-    image: ghcr.io/arturict/tagvico-ai:3.1.1
+    image: ghcr.io/arturict/tagvico-ai:3.1.2
     container_name: tagvico-ai
     restart: unless-stopped
     cap_drop:
@@ -131,7 +131,7 @@ docker run -d \
   -e TAGVICO_AI_PORT=3000 \
   -e ALLOW_REMOTE_SETUP=yes \
   -v tagvico_ai_data:/app/data \
-  ghcr.io/arturict/tagvico-ai:3.1.1
+  ghcr.io/arturict/tagvico-ai:3.1.2
 ```
 
 After setup, remove `ALLOW_REMOTE_SETUP=yes` unless you specifically need to


### PR DESCRIPTION
## Summary
- exclude colon/slash-delimited embedding-only models from chat pickers
- add Ollama model ID regression coverage
- publish the focused 3.1.2 patch metadata and docs

## Verification
- npm run check
- Node 22 companion model tests (13/13)
- npm run docs:build
- production Docker build and health/docs smoke