### PR TITLE
Refresh v3.2.5 status and community launch kit

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,12 +1,14 @@
 # Project status
 
-**Status:** stable v3 (`3.0.0`).
+**Status:** stable v3. The latest stable patch is `3.2.5`.
 
 ## Stable v3 contract
 
-Tagvico AI v3.0.0 adds an accountable action and approval layer to the stable,
-reviewable Paperless-ngx filing workflow. The following are compatibility
-commitments for v3:
+Tagvico AI v3.0.0 established the accountable action and approval layer for the
+stable, reviewable Paperless-ngx workflow. The current v3.2.5 release improves
+first-run verification, source-backed answers, recovery, privacy-safe aggregate
+metrics, and responsive product states without changing the v3 compatibility
+contract. The following are commitments for the complete v3 release line:
 
 - Existing v2 and v3 data volumes are upgraded with versioned, idempotent SQLite
   migrations and a pre-migration database backup.
@@ -19,14 +21,16 @@ commitments for v3:
 
 The household, Action Case, checklist, approval, and encrypted member-token
 records introduced by schema v5 are also preserved through compatible v3
-upgrades. Breaking changes to these contracts require a new major version. Provider
-model names, prices, quotas, and account entitlements remain controlled by the
-provider and can change independently of Tagvico.
+upgrades. Breaking changes to these contracts require a new major version.
+Provider model names, prices, quotas, and account entitlements remain controlled
+by the provider and can change independently of Tagvico.
 
 ## Recommended deployment policy
 
-- Pin `ghcr.io/arturict/tagvico-ai:3.0.0` rather than `latest` when you need
-  explicit change control and unambiguous rollback.
+- Check the [GitHub releases page](https://github.com/arturict/tagvico-ai/releases)
+  before installing or upgrading. The current recommendation is to pin
+  `ghcr.io/arturict/tagvico-ai:3.2.5` rather than `latest` for explicit change
+  control and unambiguous rollback.
 - Back up the complete `tagvico_ai_data` volume before every upgrade.
 - Start in **Review first** and test representative, non-sensitive documents
   before enabling Automatic mode.
@@ -45,4 +49,4 @@ Security issues must not be filed publicly; follow
 
 Release-specific upgrade and rollback instructions are available on the
 [GitHub releases page](https://github.com/arturict/tagvico-ai/releases) and in
-  the [versioned v3 documentation](https://tagvico.arturf.ch/docs/).
+the [versioned v3 documentation](https://tagvico.arturf.ch/docs/).

--- a/docs/launch-post.md
+++ b/docs/launch-post.md
@@ -1,78 +1,147 @@
 # Community launch kit
 
-Use these drafts sequentially, at least 24 hours apart, after checking each
-community's current self-promotion rules. Stay available to answer replies.
+These drafts match stable Tagvico v3.2.5. Check each community's current
+self-promotion rules immediately before posting, publish one substantial post
+at a time, and stay available to answer replies. Do not cross-post identical
+copy.
 
-## r/selfhosted / New Project thread
+## What to validate with this launch
 
-**Title:** I built a self-hosted, review-first AI filing companion for Paperless-ngx
+The goal is not raw impressions. Look for evidence that Paperless users can:
 
-I built Tagvico AI to reduce the repetitive cleanup after documents arrive in
-Paperless-ngx. It reads the OCR text Paperless already has and proposes titles,
-tags, correspondents, document types, dates, languages, custom fields, and
-optional owner assignments.
+1. understand Tagvico's role without mistaking it for a Paperless replacement;
+2. complete setup and verify Paperless plus one model provider;
+3. ask a useful archive question and inspect its cited source;
+4. review a proposed write before approving it; and
+5. explain the next workflow problem they would trust Tagvico to handle.
 
-The part I care about most is control: suggestions can wait in a durable review
-queue, generated tags can be constrained to a controlled vocabulary, and local
-Ollama or an OpenAI-compatible endpoint can keep classification on your own
-network. Hosted providers are optional and explicit.
+Use privacy-safe aggregate traffic only. Do not collect document content,
+private endpoints, account identifiers, or permanent installation identifiers.
 
-Version 2.0 is stable, runs in Docker, and is MIT licensed. Pin the release,
-back up the volume, and start in Review-first mode.
+## r/selfhosted New Project Megathread
 
-GitHub: https://github.com/arturict/tagvico-ai
+Projects younger than three months belong in the current weekly New Project
+Megathread, not in a standalone post. Use a top-level comment with the
+community's requested fields:
 
-I would especially value feedback on installation friction and which metadata
-guardrails work in real household or small-office archives.
+**Project Name:** Tagvico
+
+**Repo/Website Link:**
+
+- https://github.com/arturict/tagvico-ai
+- https://tagvico.arturf.ch/
+
+**Description:** I built Tagvico because finding a document is often only the
+start of the work. An invoice creates a payment, a letter creates a deadline,
+and a household document often needs to be checked or shared with someone else.
+
+Tagvico connects to an existing Paperless-ngx archive. It answers questions
+with visible document sources, proposes structured metadata and follow-up
+actions, and keeps every document write behind an explicit approval card.
+Paperless remains the system of record.
+
+Stable v3.2.5 includes guided connection verification, source-backed answers,
+durable conversations and approvals, metadata restoration, recovery queues,
+and a responsive interface. New installations start in Review first mode with
+scheduled scans paused.
+
+**Deployment:** Tagvico is MIT licensed and distributed as a Docker image with
+a Compose example and versioned installation documentation. Pin the immutable
+v3.2.5 image, connect an existing Paperless-ngx instance, and choose local
+Ollama or an explicitly configured hosted provider.
+
+Tagvico does not operate a document-processing cloud service, but a hosted
+provider you choose may receive the content required for that request.
+
+**AI Involvement:** Tagvico is explicitly an AI product. Models provide archive
+answers and metadata or action proposals within the visible source and approval
+boundaries. I also use AI coding and review tools during development. Releases
+are checked with typed contracts, security boundaries, 201 automated tests,
+real-Paperless acceptance, multiarchitecture container tests, and human review.
+
+I would value blunt feedback about setup friction and the first action you
+would trust after finding a document.
 
 ## r/Paperlessngx
 
-**Title:** Tagvico AI: review-first AI metadata for Paperless-ngx — looking for workflow feedback
+**Title:** Tagvico v3.2.5: a review-first action and research layer for Paperless-ngx
 
-I maintain Tagvico AI, an independent self-hosted companion for Paperless-ngx.
-It proposes structured filing metadata from existing OCR text and either queues
-the diff for approval or writes validated fields automatically.
+I maintain Tagvico, an independent self-hosted companion for Paperless-ngx.
+Paperless remains the document system of record. Tagvico adds source-backed
+archive questions, reviewable metadata proposals, exact restoration, and
+follow-up actions without granting an assistant unsupervised write access.
 
-Current features include controlled tag groups, metadata restoration, OCR
-rescue, processing history, custom fields, owner assignment, local Ollama, and
-optional hosted providers. No document content is routed through a
-Tagvico-operated service.
+The current setup verifies Paperless permissions, authenticates the selected
+model provider, loads its live model catalog, and checks the exact model before
+creating the owner account. New installations begin in Review first mode with
+scheduled scans paused.
+
+The supported paths include local Ollama, OpenRouter, OpenAI-compatible
+gateways, OpenAI, GitHub Copilot, OpenCode Go, Ollama Cloud, and experimental
+ChatGPT subscription access. Provider behavior and data handling remain the
+operator's explicit choice.
+
+Website and documentation: https://tagvico.arturf.ch/
 
 Repository and Compose example: https://github.com/arturict/tagvico-ai
 
-Version 2.0 is the first stable release. I would still value blunt
-Paperless-specific feedback: does the review queue fit your workflow, which
-fields should default to existing values only, and what would make you trust
-automatic mode?
+I would especially value Paperless-specific feedback: which post-retrieval
+task should Tagvico handle, and what evidence would you need before approving a
+proposed change?
 
 ## Show HN
 
-**Title:** Show HN: Tagvico AI – self-hosted, reviewable AI metadata for Paperless-ngx
+**Title:** Show HN: Tagvico, a self-hosted action center for Paperless-ngx
 
-Tagvico AI connects to an existing Paperless-ngx installation, reads OCR text,
-and proposes structured document metadata. The main design goal is a visible
-safety boundary: reviewable diffs, controlled vocabularies, restoration, local
-model support, and optional hosted providers instead of a mandatory cloud.
+Tagvico connects to an existing Paperless-ngx archive and turns retrieval into
+reviewable work. It answers archive questions with visible sources, proposes
+metadata and follow-up actions, and requires explicit approval before document
+writes.
 
-It is TypeScript, Docker, SQLite, and MIT licensed. Version 2.0 is stable, and I
-am looking for feedback from people running real document archives.
+Paperless remains the system of record. Tagvico is TypeScript, Docker, SQLite,
+and MIT licensed. It supports local models and explicitly configured hosted
+providers instead of requiring a Tagvico-operated AI service.
+
+The current stable release is v3.2.5:
+
+https://tagvico.arturf.ch/
 
 https://github.com/arturict/tagvico-ai
 
+I am looking for feedback from people running real document archives:
+what should happen after you find the right document?
+
 ## Provider communities
 
-Adapt the short draft below for Ollama, OpenRouter, or compatible-gateway
-communities. Do not cross-post identical text or imply provider endorsement.
+Adapt this only when a real provider-specific result is available. Do not imply
+provider endorsement.
 
-> I am testing **[provider/model]** for structured Paperless-ngx metadata in
-> Tagvico AI. The useful question is not prose quality but field accuracy across
-> titles, dates, tags, correspondents, and custom fields. If you run this model
-> for document extraction, I would value sanitized examples of where it fails.
+> I am testing **[provider/model]** in Tagvico for source-backed Paperless-ngx
+> questions and structured metadata proposals. The useful question is not
+> generic prose quality but whether the answer cites the right document and the
+> proposed fields remain reviewable and accurate. If you use this model for
+> document workflows, I would value sanitized failure cases.
+>
 > Project: https://github.com/arturict/tagvico-ai
+
+## Response prompts
+
+When someone shows interest, ask only one focused follow-up:
+
+- What is the first task you do after finding the document?
+- Which Paperless version and deployment style are you using?
+- Did setup fail at Paperless, provider authentication, or model verification?
+- What would you need to see before approving the proposed write?
+
+Move reproducible bugs to GitHub after removing credentials, private URLs,
+document contents, names, and account identifiers.
 
 ## Visual asset checklist
 
-- 60–90 second screen recording from a representative installation.
-- Show arrival → suggestion → diff review → Paperless result.
-- Use synthetic documents and inspect every final frame for identifiers.
-- Export one short GIF for the README and two captioned stills for posts.
+- Record 60 to 90 seconds on a representative v3.2.5 installation.
+- Use synthetic documents throughout.
+- Show question, visible source, proposed action, approval, and Paperless result.
+- Inspect every final frame for credentials, endpoints, names, document content,
+  email addresses, account identifiers, and private URLs.
+- Export one short video and two captioned stills. Avoid a large animated GIF
+  that makes the repository page slow.


### PR DESCRIPTION
## What changed

- update the project status to identify v3.2.5 as the latest stable patch while
  preserving v3.0.0 as the compatibility-contract baseline
- recommend the immutable v3.2.5 image and current release notes for installs
  and upgrades
- replace the obsolete v2 launch drafts with current r/selfhosted,
  r/Paperlessngx, Show HN, and provider-community copy
- add privacy-safe launch goals, focused response prompts, and a sanitized
  visual-asset checklist

## Why

The repository, public documentation, release, and representative deployment
have moved to v3.2.5, while `docs/STATUS.md` still recommended v3.0.0 and the
community launch kit still described v2 as the current product. The old copy
also positioned Tagvico mainly as an AI metadata helper instead of the current
source-backed action and research layer with explicit write approval.

## Impact

Operators get a current immutable image recommendation. Future community posts
describe the product and provider privacy boundary accurately and ask for
workflow evidence rather than vanity metrics.

## Validation

- Node 22.23.1
- complete `npm test`: 201 of 201 tests passed
- `npm run docs:build`: v1, v2, and v3 builds passed
- `npm audit --omit=dev --audit-level=high`: zero vulnerabilities
- `git diff --check`
- Prettier check for both changed files

GitHub Actions are intentionally disabled until the monthly quota resets. This
PR remains a draft until the required remote check can run again.
