### PR TITLE
Disable remote setup by default in Unraid template

### DIFF
--- a/deploy/unraid/tagvico-ai.xml
+++ b/deploy/unraid/tagvico-ai.xml
@@ -10,6 +10,6 @@
   <Icon>https://raw.githubusercontent.com/arturict/tagvico-ai/main/public/tagvico-icon.png</Icon>
   <Config Name="Web UI" Target="3000" Default="8080" Mode="tcp" Description="Tagvico web interface" Type="Port" Display="always" Required="true" Mask="false">8080</Config>
   <Config Name="Persistent data" Target="/app/data" Default="/mnt/user/appdata/tagvico-ai" Mode="rw" Description="Configuration, history, and local admin data" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/tagvico-ai</Config>
-  <Config Name="Allow remote setup" Target="ALLOW_REMOTE_SETUP" Default="yes" Mode="" Description="Disable after first setup when appropriate" Type="Variable" Display="always" Required="true" Mask="false">yes</Config>
+  <Config Name="Allow remote setup" Target="ALLOW_REMOTE_SETUP" Default="no" Mode="" Description="Set to yes temporarily to opt in to remote setup" Type="Variable" Display="always" Required="true" Mask="false">no</Config>
   <Config Name="Anonymous analytics" Target="TAGVICO_TELEMETRY_ENABLED" Default="no" Mode="" Description="Optional aggregate installation heartbeat" Type="Variable" Display="always" Required="true" Mask="false">no</Config>
 </Container>


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated remote first-run setup by changing the Unraid container template's `ALLOW_REMOTE_SETUP` default to `no`, aligning the deployment default with the safer value in `.env.example` and avoiding possible instance takeover during onboarding.

### Description
- Update `deploy/unraid/tagvico-ai.xml` to set the `ALLOW_REMOTE_SETUP` `Config` `Default` and value to `no` and clarify the description to indicate remote setup must be explicitly and temporarily enabled to opt in.

### Testing
- Ran `git diff --check`, parsed `deploy/unraid/tagvico-ai.xml` with Python `xml.etree.ElementTree` and asserted the `ALLOW_REMOTE_SETUP` `Default` and text are `no`, and executed `npm run check`; all automated checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69fe40c258832bbd92cdd64add8a70)