### PR TITLE
Secure local Docker Compose exposure defaults

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,7 @@ services:
       paperless-broker:
         condition: service_healthy
     ports:
-      - "${PAPERLESS_HOST_PORT:-8000}:8000"
+      - "${PAPERLESS_BIND_ADDRESS:-127.0.0.1}:${PAPERLESS_HOST_PORT:-8000}:8000"
     environment:
       PAPERLESS_REDIS: redis://paperless-broker:6379
       PAPERLESS_DBHOST: paperless-db
@@ -83,7 +83,7 @@ services:
       TAGVICO_AI_PORT: 3000
       PAPERLESS_API_URL: http://paperless-ngx:8000/api
       CODEX_HOME: /app/data/codex
-      ALLOW_REMOTE_SETUP: "yes"
+      ALLOW_REMOTE_SETUP: "${ALLOW_REMOTE_SETUP:-no}"
       TELEGRAM_BOT_ENABLED: ${TELEGRAM_BOT_ENABLED:-no}
       TELEGRAM_BOT_TOKEN: ${TELEGRAM_BOT_TOKEN:-}
       TELEGRAM_USERS_JSON: ${TELEGRAM_USERS_JSON:-[]}
@@ -95,7 +95,7 @@ services:
       # Explicit opt-in: this bypasses Tagvico's web review queue for bot uploads.
       TELEGRAM_UPLOAD_AUTOMATIC_METADATA: ${TELEGRAM_UPLOAD_AUTOMATIC_METADATA:-no}
     ports:
-      - "${TAGVICO_AI_HOST_PORT:-${ARCHIVISTA_AI_HOST_PORT:-8080}}:3000"
+      - "${TAGVICO_AI_BIND_ADDRESS:-127.0.0.1}:${TAGVICO_AI_HOST_PORT:-${ARCHIVISTA_AI_HOST_PORT:-8080}}:3000"
     volumes:
       - tagvico_ai_data:/app/data
 


### PR DESCRIPTION
### Motivation

- Close an accidental deployment-default security hole where `paperless-ngx` and the app were published on all host interfaces with predictable local test credentials and remote first-run setup enabled.
- Preserve the existing local integration-test experience while making safe defaults that avoid exposing admin credentials or setup flows to LAN/internet by mistake.

### Description

- Restrict `paperless-ngx` host binding by adding a `PAPERLESS_BIND_ADDRESS` override and defaulting the port mapping to `127.0.0.1` via `"${PAPERLESS_BIND_ADDRESS:-127.0.0.1}:${PAPERLESS_HOST_PORT:-8000}:8000"` in `docker-compose.yml`.
- Disable Tagvico remote first-run setup by default by making `ALLOW_REMOTE_SETUP` opt-in via `ALLOW_REMOTE_SETUP: "${ALLOW_REMOTE_SETUP:-no}"` in `docker-compose.yml`.
- Restrict Tagvico host binding by adding a `TAGVICO_AI_BIND_ADDRESS` override and defaulting its port mapping to loopback via `"${TAGVICO_AI_BIND_ADDRESS:-127.0.0.1}:${TAGVICO_AI_HOST_PORT:-${ARCHIVISTA_AI_HOST_PORT:-8080}}:3000"` in `docker-compose.yml`.
- Keep changes minimal and backwards-compatible by exposing explicit environment variable overrides for operators who intentionally need remote access.

### Testing

- Ran a content assertion script that verified the new loopback bindings and the `ALLOW_REMOTE_SETUP` default and it passed.
- Executed `npm run check` (typecheck, lint and project checks) and all checks completed successfully.
- Ran `git diff --check` to validate the working tree for obvious issues and it reported no problems.
- Attempted to render Compose with `docker compose config` but Docker/Docker Compose were not available in the environment, so full Compose rendering validation could not be performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a0845d978832bb2433110640e6095)