### PR TITLE
Add Umami to the public landing page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -16,6 +16,7 @@
     >
     <meta name="theme-color" content="#f5f2e8">
     <meta name="tagvico-metrics-endpoint" content="https://telemetry.tagvico.arturf.ch">
+    <script defer src="https://umami.arturf.ch/script.js" data-website-id="32125e56-263c-42ee-a556-a2f2867a9b94"></script>
     <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1">
     <link rel="canonical" href="https://tagvico.arturf.ch/">
     <link rel="icon" href="/favicon.ico" sizes="any">


### PR DESCRIPTION
## Summary
- load the owner-provided Umami tracker on the standalone landing page
- keep the Tagvico app and versioned documentation unchanged

## Validation
- git diff --check`n- verified the website ID appears exactly once
- verified docs/index.html is the only changed file