### PR TITLE
fix: remove Umami from legacy docs landing

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -16,7 +16,6 @@
     >
     <meta name="theme-color" content="#f5f2e8">
     <meta name="tagvico-metrics-endpoint" content="https://telemetry.tagvico.arturf.ch">
-    <script defer src="https://umami.arturf.ch/script.js" data-website-id="32125e56-263c-42ee-a556-a2f2867a9b94"></script>
     <meta name="robots" content="index,follow,max-image-preview:large,max-snippet:-1,max-video-preview:-1">
     <link rel="canonical" href="https://tagvico.arturf.ch/">
     <link rel="icon" href="/favicon.ico" sizes="any">


### PR DESCRIPTION
## Summary
- remove the Tagvico Umami snippet from the legacy `docs/index.html` landing copy
- tracking now lives in the separate `tagvico-ai-site` repository, where the production landing page is built

## Verification
- `git diff --check`