### PR TITLE
feat: restore Paperless network discovery in first-run setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2627,9 +2627,9 @@
       }
     },
     "node_modules/@mermaid-js/parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.0.tgz",
-      "integrity": "sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.2.1.tgz",
+      "integrity": "sha512-n12NohV3mrUyUL2o93IgG/ifeW9FTyeJn3zDxkhwa8MJ9Fxg3HQMlA3RiGmD/3UnJvheztkjjQAjA2T4LmUcpw==",
       "license": "MIT",
       "dependencies": {
         "@chevrotain/types": "~11.1.2"
@@ -7284,9 +7284,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8604,9 +8604,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.12",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.12.tgz",
-      "integrity": "sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==",
+      "version": "3.4.14",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.14.tgz",
+      "integrity": "sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -9726,6 +9726,15 @@
         }
       ],
       "license": "BSD-3-Clause"
+    },
+    "node_modules/fastdom": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/fastdom/-/fastdom-1.0.12.tgz",
+      "integrity": "sha512-LB+xjSTEbjHE1cWsxu+tN2Xqr1kpi+V9aADI7sVM5ZMaXyYGPHULQMzpJMYqOTULK/73pUkWVzzObFRBkPr+hg==",
+      "license": "MIT",
+      "dependencies": {
+        "strictdom": "^1.0.1"
+      }
     },
     "node_modules/fastq": {
       "version": "1.20.1",
@@ -11306,9 +11315,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -12306,26 +12315,27 @@
       }
     },
     "node_modules/mermaid": {
-      "version": "11.16.0",
-      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.16.0.tgz",
-      "integrity": "sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==",
+      "version": "11.17.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.17.0.tgz",
+      "integrity": "sha512-Jo9N377Wb4MSnHFPTbLi2SxFpsQl4eVHoxnW5U1Md9EazvgMp3s+4ohDxr81YNTgbn5Kj7HJ3yslrSJ52kwpbA==",
       "license": "MIT",
       "dependencies": {
         "@braintree/sanitize-url": "^7.1.2",
         "@iconify/utils": "^3.0.2",
-        "@mermaid-js/parser": "^1.2.0",
+        "@mermaid-js/parser": "^1.2.1",
         "@types/d3": "^7.4.3",
         "@upsetjs/venn.js": "^2.0.0",
-        "cytoscape": "^3.33.3",
+        "cytoscape": "^3.34.0",
         "cytoscape-cose-bilkent": "^4.1.0",
         "cytoscape-fcose": "^2.2.0",
         "d3": "^7.9.0",
         "d3-sankey": "^0.12.3",
         "dagre-d3-es": "7.0.14",
-        "dayjs": "^1.11.20",
+        "dayjs": "^1.11.21",
         "dompurify": "^3.3.3",
         "es-toolkit": "^1.45.1",
-        "katex": "^0.16.45",
+        "fastdom": "1.0.12",
+        "katex": "^0.16.47",
         "khroma": "^2.1.0",
         "marked": "^16.3.0",
         "roughjs": "^4.6.6",
@@ -13114,9 +13124,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -15327,6 +15337,12 @@
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
       }
+    },
+    "node_modules/strictdom": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strictdom/-/strictdom-1.0.1.tgz",
+      "integrity": "sha512-cEmp9QeXXRmjj/rVp9oyiqcvyocWab/HaoN4+bwFeZ7QzykJD6L3yD4v12K1x0tHpqRqVpJevN3gW7kyM39Bqg==",
+      "license": "MIT"
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",

--- a/routes/setup.ts
+++ b/routes/setup.ts
@@ -31,6 +31,7 @@ interface Res {
 }
 type Next = (error?: unknown) => unknown;
 const router = express.Router();
+const os = require('node:os');
 const axios = require('axios');
 const setupService = require('../services/setupService.js');
 const paperlessService = require('../services/paperlessService.js');
@@ -2606,6 +2607,31 @@ async function probePaperlessInstance(baseUrl: string, timeout = 2500, token = '
 /**
  * Build a candidate list of base URLs to probe for Paperless-ngx auto-discovery.
  */
+// Sweeping every attached network is what lets discovery work inside Docker:
+// a container sits on a bridge such as 172.18.0.0/16 and its Paperless neighbour
+// is a few addresses along, which a hardcoded home-LAN range never reaches.
+const DISCOVERY_MAX_SWEPT_SUBNETS = 3;
+
+/**
+ * Returns the /24 prefixes worth enumerating, taken from this machine's own
+ * IPv4 interfaces. Wider networks (a /16 Docker bridge) are narrowed to the /24
+ * holding our own address, because Docker and DHCP hand out addresses from the
+ * bottom of the range rather than scattering them across 65k hosts.
+ */
+function localSweepPrefixes(): string[] {
+  const prefixes = new Set<string>();
+  for (const addresses of Object.values(os.networkInterfaces() || {})) {
+    for (const address of (addresses || []) as Array<{ family: string; internal: boolean; address: string }>) {
+      if (address.family !== 'IPv4' || address.internal) continue;
+      const octets = address.address.split('.');
+      if (octets.length !== 4) continue;
+      prefixes.add(octets.slice(0, 3).join('.'));
+      if (prefixes.size >= DISCOVERY_MAX_SWEPT_SUBNETS) return Array.from(prefixes);
+    }
+  }
+  return Array.from(prefixes);
+}
+
 function buildDiscoveryCandidates(hint: string | undefined) {
   const candidates = new Set();
   const add = (u: string | undefined) => {
@@ -2625,10 +2651,14 @@ function buildDiscoveryCandidates(hint: string | undefined) {
   ['http://localhost:8000', 'http://127.0.0.1:8000', 'http://host.docker.internal:8000']
     .forEach(add);
 
-  // Common homelab/LAN addresses. This intentionally includes the local /24 so
-  // setup does not only rely on Docker DNS names.
-  for (let host = 1; host <= 254; host += 1) {
-    add(`http://192.168.1.${host}:8000`);
+  // Every network this machine is actually on, plus the most common homelab
+  // range. 192.168.1.0/24 stays in the list because a bridged container reaches
+  // the host LAN through NAT while its own addresses are all 172.x.
+  const sweptPrefixes = new Set([...localSweepPrefixes(), '192.168.1']);
+  for (const prefix of sweptPrefixes) {
+    for (let host = 1; host <= 254; host += 1) {
+      add(`http://${prefix}.${host}:8000`);
+    }
   }
 
   // If the hint points at a host, also try the standard Paperless port on that host.
@@ -2670,6 +2700,28 @@ async function validatePaperlessTokenPermissions(baseUrl: string, token: string,
   return { success: true, message: 'Paperless token can read documents and metadata.' };
 }
 
+// Sweeping several /24s means ~1000 probes per scan. Opening them all at once
+// exhausts the default file-descriptor limit, so run a bounded pool instead:
+// unreachable addresses cost a full probe timeout, and 256 in flight keeps the
+// whole sweep inside the 15s budget the settings proxy allows.
+const DISCOVERY_PROBE_CONCURRENCY = 256;
+
+async function probeDiscoveryCandidates(candidates: string[]) {
+  const results: Array<Awaited<ReturnType<typeof probePaperlessInstance>>> = [];
+  let next = 0;
+  const worker = async () => {
+    while (next < candidates.length) {
+      const index = next;
+      next += 1;
+      results[index] = await probePaperlessInstance(candidates[index]);
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(DISCOVERY_PROBE_CONCURRENCY, candidates.length) }, worker)
+  );
+  return results;
+}
+
 /**
  * POST /api/paperless/discover
  * Scans a curated set of candidate URLs (plus an optional hint) for reachable
@@ -2679,7 +2731,7 @@ router.post('/api/paperless/discover', allowDuringSetup, express.json(), async (
   try {
     const hint = String((req.body && req.body.hint) || (req.query && req.query.hint) || '');
     const candidates = buildDiscoveryCandidates(hint);
-    const results = await Promise.all(candidates.map((url) => probePaperlessInstance(String(url))));
+    const results = await probeDiscoveryCandidates(candidates.map(String));
     const instances = results
       .filter((r) => r.ok)
       // de-duplicate by normalized url

--- a/src/app/api/paperless/discovery/route.ts
+++ b/src/app/api/paperless/discovery/route.ts
@@ -22,7 +22,9 @@ export async function POST(request: Request) {
       body: JSON.stringify({ hint: String(hint || '').slice(0, 2048) }),
       cache: 'no-store',
       redirect: 'manual',
-      signal: AbortSignal.timeout(15_000)
+      // A full sweep probes every attached /24, so allow for the slowest case
+      // where most addresses are firewalled and burn their whole probe timeout.
+      signal: AbortSignal.timeout(45_000)
     });
     const text = await response.text();
     return new Response(text, {

--- a/src/components/settings/paperless-discovery.tsx
+++ b/src/components/settings/paperless-discovery.tsx
@@ -13,7 +13,23 @@ type DiscoveredInstance = {
   requiresAuth?: boolean;
 };
 
-export function PaperlessDiscovery({ baseUrl }: { baseUrl: string }) {
+type PaperlessDiscoveryProps = {
+  baseUrl: string;
+  /**
+   * Settings runs discovery through the authenticated Next route. First-run setup has no
+   * owner yet and uses the backend endpoint, which the setup middleware opens until the
+   * installation is configured.
+   */
+  endpoint?: string;
+  /** When provided, each result offers to fill the connection form instead of only reporting. */
+  onSelect?: (url: string) => void;
+};
+
+export function PaperlessDiscovery({
+  baseUrl,
+  endpoint = '/api/paperless/discovery',
+  onSelect
+}: PaperlessDiscoveryProps) {
   const [scanning, setScanning] = useState(false);
   const [error, setError] = useState('');
   const [instances, setInstances] = useState<DiscoveredInstance[]>([]);
@@ -23,13 +39,13 @@ export function PaperlessDiscovery({ baseUrl }: { baseUrl: string }) {
     setScanning(true);
     setError('');
     try {
-      const response = await fetch('/api/paperless/discovery', {
+      const response = await fetch(endpoint, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ hint: baseUrl })
       });
       const body = await response.json().catch(() => ({}));
-      if (!response.ok) throw new Error(body.error || 'Paperless discovery failed.');
+      if (!response.ok || body.success === false) throw new Error(body.error || 'Paperless discovery failed.');
       setInstances(Array.isArray(body.instances) ? body.instances : []);
       setScanned(Number(body.scanned || 0));
     } catch (scanError) {
@@ -62,7 +78,13 @@ export function PaperlessDiscovery({ baseUrl }: { baseUrl: string }) {
             {instance.requiresAuth ? ' · authentication required' : ''}
           </small>
         </span>
-        <span className="settings-badge">Read only</span>
+        {onSelect ? <button
+          className="settings-button"
+          type="button"
+          onClick={() => onSelect(instance.url)}
+        >
+          Use this URL
+        </button> : <span className="settings-badge">Read only</span>}
       </li>)}
     </ul> : null}
   </div>;

--- a/src/components/settings/setup-wizard.tsx
+++ b/src/components/settings/setup-wizard.tsx
@@ -4,6 +4,7 @@ import { useEffect, useMemo, useRef, useState, type FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import { Check, FileStack, KeyRound, Sparkles } from 'lucide-react';
 import { InlineStatus } from './inline-status';
+import { PaperlessDiscovery } from './paperless-discovery';
 import { SettingsRow, SettingsSection } from './settings-section';
 import type { ProviderDescriptor } from './types';
 
@@ -161,6 +162,14 @@ export function SetupWizard({ providers }: { providers: ProviderDescriptor[] }) 
       message: modelId
         ? 'Model changed. Check the runtime again to verify this exact model.'
         : 'Choose or enter a model, then check the runtime.'
+    });
+  };
+
+  const useDiscoveredPaperless = (url: string) => {
+    update('paperlessUrl', url);
+    setStatus({
+      kind: 'neutral',
+      message: `Using ${url}. Add an API token, then check Paperless.`
     });
   };
 
@@ -447,6 +456,17 @@ export function SetupWizard({ providers }: { providers: ProviderDescriptor[] }) 
             />
           </label>
         </div>
+      </SettingsRow>
+      <SettingsRow
+        title="Find Paperless-ngx"
+        description="Not sure about the address? Scan common Docker, host and local-network addresses. Discovery is read-only and only fills the Base URL when you pick a result."
+        stack
+      >
+        <PaperlessDiscovery
+          baseUrl={state.paperlessUrl}
+          endpoint="/api/paperless/discover"
+          onSelect={useDiscoveredPaperless}
+        />
       </SettingsRow>
     </SettingsSection> : null}
 

--- a/tests/onboarding-product-quality.test.js
+++ b/tests/onboarding-product-quality.test.js
@@ -34,7 +34,19 @@ test('first-run setup verifies both dependencies and resumes without browser-sto
   assert.match(wizard, /<PaperlessDiscovery/);
   assert.match(wizard, /endpoint="\/api\/paperless\/discover"/);
   assert.match(wizard, /onSelect=\{useDiscoveredPaperless\}/);
-  assert.match(read('routes/setup.ts'), /router\.post\('\/api\/paperless\/discover', allowDuringSetup/);
+  const setupRoutes = read('routes/setup.ts');
+  assert.match(setupRoutes, /router\.post\('\/api\/paperless\/discover', allowDuringSetup/);
+  // Discovery has to reach a Paperless container on the same Docker bridge, not
+  // just the hardcoded home-LAN range, so the sweep comes from real interfaces.
+  assert.match(setupRoutes, /function localSweepPrefixes/);
+  assert.match(setupRoutes, /os\.networkInterfaces\(\)/);
+  assert.match(setupRoutes, /new Set\(\[\.\.\.localSweepPrefixes\(\), '192\.168\.1'\]\)/);
+  assert.match(setupRoutes, /'paperless-webserver'/);
+  assert.match(setupRoutes, /host\.docker\.internal/);
+  // ~1000 probes per sweep must not open ~1000 sockets at once.
+  assert.match(setupRoutes, /DISCOVERY_PROBE_CONCURRENCY = 256/);
+  assert.match(setupRoutes, /await probeDiscoveryCandidates\(candidates\.map\(String\)\)/);
+  assert.doesNotMatch(setupRoutes, /Promise\.all\(candidates\.map/);
   assert.match(wizard, /Restored non-secret fields for this tab/);
   assert.match(wizard, /Object\.entries\(state\.providerValues\)\.filter/);
 

--- a/tests/onboarding-product-quality.test.js
+++ b/tests/onboarding-product-quality.test.js
@@ -31,6 +31,10 @@ test('first-run setup verifies both dependencies and resumes without browser-sto
     read('routes/setup.ts'),
     /status\.models\.includes\(\s*effectiveSetupConfig\.COPILOT_MODEL \|\| effectiveSetupConfig\.AI_MODEL/
   );
+  assert.match(wizard, /<PaperlessDiscovery/);
+  assert.match(wizard, /endpoint="\/api\/paperless\/discover"/);
+  assert.match(wizard, /onSelect=\{useDiscoveredPaperless\}/);
+  assert.match(read('routes/setup.ts'), /router\.post\('\/api\/paperless\/discover', allowDuringSetup/);
   assert.match(wizard, /Restored non-secret fields for this tab/);
   assert.match(wizard, /Object\.entries\(state\.providerValues\)\.filter/);
 


### PR DESCRIPTION
## Where it went

It was in the old EJS setup form. `views/partials/config-form.ejs` had a **"Scan for Paperless-ngx instances"** button driven by `public/js/config-form.js` (`initPaperlessDiscovery` → `POST /api/paperless/discover`), right on the setup page. Both files were deleted in the v3 React rewrite — `scripts/check-settings-architecture.js` now asserts they never come back — and the button was only re-added to Settings, which you cannot reach until onboarding is finished. So on a fresh install it disappeared.

The backend endpoint survived the rewrite untouched and is still open during onboarding: `/api/paperless/discover` is in `PUBLIC_ROUTES` behind `allowDuringSetup` (loopback-only unless `ALLOW_REMOTE_SETUP=yes`), with a comment saying it is "needed during onboarding before an admin exists." Only the caller was missing.

## Restoring the button

- `PaperlessDiscovery` takes an optional `endpoint` (defaulting to the authenticated Next route Settings uses) and an optional `onSelect`.
- With `onSelect`, each result renders **Use this URL** instead of the read-only badge, so setup fills the Base URL in one click. Settings is unchanged.
- Setup step 1 gets a **Find Paperless-ngx** row pointing at `/api/paperless/discover`.
- Discovery now treats a `success: false` body as an error, not only a non-2xx status.

## Making it actually reach the Docker network

The candidate list has been unchanged since 1.0.0, and its LAN sweep was a hardcoded `192.168.1.0/24`. Docker service names (`paperless`, `paperless-ngx`, `paperless-webserver`, `webserver`, `paperlessngx`) and `host.docker.internal` were covered, but a Tagvico container whose Paperless neighbour sits on a `172.18.0.0/16` bridge under a non-matching service name was never going to find it.

- `localSweepPrefixes()` derives the /24s from this machine's own non-internal IPv4 interfaces. A `/16` bridge is narrowed to the /24 holding our own address, because Docker and DHCP allocate from the bottom of the range rather than scattering across 65k hosts. Capped at 3 subnets.
- `192.168.1.0/24` stays in the list: a bridged container reaches the host LAN through NAT while all of its own addresses are `172.x`.
- That grows a scan from ~260 to ~1000 probes. `Promise.all` over all of them would open ~1000 sockets and hit the default 1024 fd limit, so probes run through a 256-wide worker pool.
- The settings proxy timeout goes from 15s to 45s to cover a sweep where most addresses are firewalled and burn their full probe timeout.

## Dependency audit (bundled to unblock the merge)

The `quality` job's audit step had been failing on `main` for every PR — js-yaml and nanoid at high, dompurify and mermaid at moderate — and it is a required status check. Lockfile only, no `package.json` change: mermaid 11.16.0→11.17.0 (plus its new `fastdom` / `strictdom` transitives), dompurify 3.4.12→3.4.14, js-yaml 4.3.0→4.3.1, nanoid 3.3.16→3.3.18, brace-expansion 1.1.16→1.1.18.

Regenerated with npm 10 to match the Node 22 runner. npm 11 dedupes the React 18 copy nested under `@docsearch/js`, which yields a tree npm 10 rejects as out of sync, so the nested copy is preserved and the docs search widget is untouched.

## Verification

Ran an unconfigured instance against a temp data dir:

- `/setup` renders the scan button.
- `POST /api/paperless/discover` unauthenticated now reports `scanned: 770` (up from 262 — the two Docker bridges are being swept) and still finds the real Paperless instance on the LAN. Full sweep took **7.6s**, well inside the 45s budget.

After a clean `npm ci` under npm 10: `npm run check`, `npm run build`, the 246-test unit suite, and `npm run docs:build` for both documentation versions all pass, and `npm audit --omit=dev --audit-level=high` reports zero. New assertions in `tests/onboarding-product-quality.test.js` cover the setup wiring, the interface-derived sweep, the Docker service names, and the concurrency bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)