### PR TITLE
chore: prepare v3.3.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 3.3.0 - 2026-08-27
 
 ### Discord companion bot
 
@@ -40,6 +40,31 @@
   snowflakes, allowlist, routing, mentions, history isolation, chunking,
   attachments, CDN validation, size limits, duplicate behavior, slash commands,
   requester-bound buttons, replay rejection, and Telegram compatibility.
+
+### Paperless discovery in first-run setup
+
+- Add the "Scan for Paperless" control to the setup wizard, so a fresh
+  installation can find its Paperless-ngx instance without knowing the URL up
+  front. The wizard uses the backend endpoint that is already open during
+  onboarding and offers "Use this URL" to fill the Base URL field. Settings
+  keeps the authenticated route and the read-only badge.
+- Derive the discovery sweep from this machine's own IPv4 interfaces instead
+  of a hardcoded `192.168.1.0/24`, so a Tagvico container finds a Paperless
+  container on a `172.x` Docker bridge. A `/16` bridge is narrowed to the
+  `/24` holding our address, and `192.168.1.0/24` is kept for the
+  bridged-container-to-host-LAN case.
+
+### Landing analytics
+
+- Add self-hosted, cookie-free Umami analytics to the public landing page
+  only. The application, docs, and legacy docs landing remain telemetry-free;
+  a stray tracker on the legacy docs landing was removed in the same series.
+
+### Upgrade note
+
+- Back up `tagvico_ai_data`, pull the pinned `3.3.0` image, and recreate only
+  the Tagvico container. This release does not change the data schema. The
+  Discord companion bot stays off unless its environment variables are set.
 
 ## 3.2.6 - 2026-07-30
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tagvico-ai",
-  "version": "3.2.6",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tagvico-ai",
-      "version": "3.2.6",
+      "version": "3.3.0",
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/openai": "3.0.86",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tagvico-ai",
-  "version": "3.2.6",
+  "version": "3.3.0",
   "description": "Tagvico — the private action center and household companion for Paperless-ngx.",
   "engines": {
     "node": "^20.19.0 || ^22.13.0 || ^24.0.0"

--- a/website/versions/v3/installation.md
+++ b/website/versions/v3/installation.md
@@ -71,9 +71,10 @@ the image you pinned even when the public website changes.
 
 ## 3. Finish guided setup
 
-1. Enter the Paperless base URL without `/api`, then paste a Paperless API
-   token. Setup checks the connection and the read permissions Tagvico needs
-   before continuing.
+1. Enter the Paperless base URL without `/api`, or use **Scan for Paperless**
+   to search the attached networks and fill the field from a found
+   installation. Then paste a Paperless API token. Setup checks the connection
+   and the read permissions Tagvico needs before continuing.
 2. Choose a [model provider](./providers). Built-in endpoints are prefilled.
    Setup verifies the connection and loads its live model catalog.
 3. Select one of the verified models and create the local Tagvico owner

--- a/website/versions/v3/release-notes.md
+++ b/website/versions/v3/release-notes.md
@@ -1,5 +1,34 @@
 # Release notes
 
+## v3.3.0
+
+Released 27 August 2026.
+
+Tagvico 3.3.0 adds an optional Discord companion bot with full Telegram
+parity. Allowlisted users can ask bounded document questions with cited
+originals, upload one attachment at a time into Paperless, list active
+actions, and approve or reject proposed actions from Discord. Each user is
+configured with their own Paperless token, so Paperless remains the permission
+authority. The bot answers direct messages and, optionally, one home channel
+where only slash commands, mentions, and replies to the bot are processed —
+no privileged Message Content intent is required. Conversation history stays
+in process memory, bounded per user and channel. The bot is off unless its
+environment variables are set.
+
+First-run setup gains **Scan for Paperless**: the wizard can search the
+attached networks for a running Paperless-ngx installation and fill the Base
+URL field, instead of requiring the URL up front. Discovery now derives its
+scan ranges from the machine's own network interfaces, so a Tagvico container
+finds a Paperless container on the same Docker bridge network.
+
+The public landing page now uses self-hosted, cookie-free analytics. The
+application, bundled docs, and installed containers remain telemetry-free
+apart from the existing opt-in aggregate reporting.
+
+Upgrade by backing up `tagvico_ai_data`, pinning
+`ghcr.io/arturict/tagvico-ai:3.3.0`, and recreating only the Tagvico
+container. This release does not change the data schema.
+
 ## v3.2.6
 
 Released 30 July 2026.


### PR DESCRIPTION
Cuts the changelog for **3.3.0** and prepares the release:

- Changelog: closes the Unreleased section as `3.3.0 - 2026-08-27`; adds the missing entries for first-run Paperless discovery (#63) and the landing-page Umami analytics (#61/#62), plus the upgrade note.
- Version bump to 3.3.0 in `package.json` / `package-lock.json`.
- Docs: new v3.3.0 section in `website/versions/v3/release-notes.md` and the **Scan for Paperless** step in the installation guide. `npm run docs:build` passes.

After merge, the GitHub release `v3.3.0` will trigger the multiarch Docker publish (`3.3.0` + `latest`) and the Discord release notification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)