### PR TITLE
docs: tune agent instructions for GPT-6 Astra

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,35 @@
 # Repository agent instructions
 
+## Astra working defaults
+
+These instructions are tuned for GPT-6 Astra. They guide execution; they do not
+change the selected runtime model or expand access and external-action authority.
+
+- Infer the intended outcome from the full conversation. Treat actionable
+  requests such as “can you fix” as authorization to do the scoped work. Continue
+  through implementation and verification; answer pure advice questions as advice.
+- Resolve routine choices from evidence and state material assumptions. Ask only
+  when an unresolved answer changes scope, correctness, cost, or authority.
+  Continue independent work while waiting; incorporate steering without restarting.
+- Complete authorized preparation before seeking final approval. Reuse earlier
+  authorization; preserve the explicit deployment, communication, purchase,
+  privacy, and destructive-action limits below. Do not invent permission gates.
+- User instructions outrank skill guidelines, subject to system/developer rules.
+  If a skill blocks progress, link its exact `SKILL.md`, quote the relevant rule,
+  and explain the concrete conflict; do not present an interpretation as a rule.
+- Delegate independent investigations, disjoint edits, or reviews when parallel
+  work saves time or improves quality. Give each worker a bounded outcome and
+  file ownership; integrate centrally. Respect harness limits and explicit user
+  model choices. Skip delegation overhead for a short, coupled task.
+- Use the smallest meaningful verification for the change and complete applicable
+  repository gates. For instruction-only edits, inspect conflicts, paths, diffs
+  and secrets; skip application builds unless runtime behavior is affected.
+  Repeat passing checks only after a relevant change or new evidence. Do not add
+  tests that merely restate implementation or remove useful behavioral coverage.
+- Lead with the result in concise, plain prose. Use lists when they help scanning;
+  avoid canned summaries, jargon and performative narration. Report what changed,
+  what was verified, and material limits; never turn a local check into a live claim.
+
 ## Agy coding and review agent
 
 Agy requires a real pseudo-terminal in automated sessions. Do not invoke `agy`
@@ -17,8 +47,10 @@ immediately before the prompt; Agy otherwise may interpret the next flag as the
 prompt. Set `AGY_PTY_CLEAN=1` when plain captured output is preferred over the
 interactive spinner output.
 
-Use Claude Sonnet 4.6 or Claude Opus 4.6 for implementation work. Use Gemini
-3.5 Flash for the independent review pass when that workflow is requested.
+For Codex/Astra tasks, implement with the selected model and available native
+tools. Agy and its alternative models are optional tools for explicitly
+requested workflows, not prerequisites for editing or reviewing this repo.
+Keep the PTY wrapper requirement whenever Agy is actually used.
 
 The wrapper uses `script` from util-linux, safely quotes all arguments, and
 propagates Agy's exit status. Verify availability with:


### PR DESCRIPTION
Tagvico's agent guide required Claude/Agy for implementation, which diverted work even when GPT-6 Astra was explicitly selected. Keep Agy's PTY requirements when it is used, while allowing the selected agent to implement and verify directly.

Add concise guidance for scoped autonomy, existing authorization, skill conflicts, independent delegation, mid-task steering, communication and proportionate verification. Preserve release documentation and screenshot/privacy requirements. CLAUDE.md and application code are unchanged.

Validation: reviewed instruction conflicts, whitespace and generated-block checks, and staged Gitleaks scan passed. An independent Astra agent reviewed the instruction changes. The required CI quality gate remains in force.

Authored with GPT-6 Astra in Codex.
